### PR TITLE
Remove CI cache

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,15 +79,6 @@ jobs:
           go-version: ^1.18
       - name: checkout
         uses: actions/checkout@v2
-      - name: go-cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('module/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: container-login
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Cache has been causing uncertainty on the reliability of the tests.