### PR TITLE
Add migration for globalfee module

### DIFF
--- a/x/globalfee/keeper/migrations.go
+++ b/x/globalfee/keeper/migrations.go
@@ -1,0 +1,23 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	v2 "github.com/burnt-labs/xion/x/globalfee/migrations/v2"
+)
+
+// Migrator is a struct for handling in-place store migrations.
+type Migrator struct {
+	globalfeeSubspace paramtypes.Subspace
+}
+
+// NewMigrator returns a new Migrator.
+func NewMigrator(globalfeeSubspace paramtypes.Subspace) Migrator {
+	return Migrator{globalfeeSubspace: globalfeeSubspace}
+}
+
+// Migrate1to2 migrates from version 1 to 2.
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v2.MigrateStore(ctx, m.globalfeeSubspace)
+}

--- a/x/globalfee/migrations/v2/migration.go
+++ b/x/globalfee/migrations/v2/migration.go
@@ -1,0 +1,38 @@
+package v2
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/burnt-labs/xion/x/globalfee/types"
+)
+
+// MigrateStore performs in-place params migrations of
+// BypassMinFeeMsgTypes and MaxTotalBypassMinFeeMsgGasUsage
+// from app.toml to globalfee params.
+// The migration includes:
+// Add bypass-min-fee-msg-types params that are set
+// ["/ibc.core.channel.v1.MsgRecvPacket",
+// "/ibc.core.channel.v1.MsgAcknowledgement",
+// "/ibc.core.client.v1.MsgUpdateClient",
+// "/ibc.core.channel.v1.MsgTimeout",
+// "/ibc.core.channel.v1.MsgTimeoutOnClose"] as default and
+// add MaxTotalBypassMinFeeMsgGasUsage that is set 1_000_000 as default.
+func MigrateStore(ctx sdk.Context, globalfeeSubspace paramtypes.Subspace) error {
+	var oldGlobalMinGasPrices sdk.DecCoins
+	globalfeeSubspace.Get(ctx, types.ParamStoreKeyMinGasPrices, &oldGlobalMinGasPrices)
+	defaultParams := types.DefaultParams()
+	params := types.Params{
+		MinimumGasPrices:                oldGlobalMinGasPrices,
+		BypassMinFeeMsgTypes:            defaultParams.BypassMinFeeMsgTypes,
+		MaxTotalBypassMinFeeMsgGasUsage: defaultParams.MaxTotalBypassMinFeeMsgGasUsage,
+	}
+
+	if !globalfeeSubspace.HasKeyTable() {
+		globalfeeSubspace = globalfeeSubspace.WithKeyTable(types.ParamKeyTable())
+	}
+
+	globalfeeSubspace.SetParamSet(ctx, &params)
+
+	return nil
+}

--- a/x/globalfee/migrations/v2/v2_test/migration_test.go
+++ b/x/globalfee/migrations/v2/v2_test/migration_test.go
@@ -1,0 +1,111 @@
+package v2_test
+
+import (
+	"testing"
+
+	cometdb "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/log"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	v2 "github.com/burnt-labs/xion/x/globalfee/migrations/v2"
+
+	globalfeetypes "github.com/burnt-labs/xion/x/globalfee/types"
+)
+
+func TestMigrateStore(t *testing.T) {
+	db := cometdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+
+	storeKey := sdk.NewKVStoreKey(paramtypes.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey("mem_key")
+
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	// Create new empty subspace
+	newSubspace := paramtypes.NewSubspace(cdc,
+		codec.NewLegacyAmino(),
+		storeKey,
+		memStoreKey,
+		paramtypes.ModuleName,
+	)
+
+	// register the subspace with the v11 paramKeyTable
+	newSubspace = newSubspace.WithKeyTable(globalfeetypes.ParamKeyTable())
+
+	// check MinGasPrices isn't set
+	_, ok := getMinGasPrice(newSubspace, ctx)
+	require.Equal(t, ok, false)
+
+	// set a minGasPrice different that default value
+	minGasPrices := sdk.NewDecCoins(sdk.NewDecCoin("uatom", sdk.OneInt()))
+	newSubspace.Set(ctx, globalfeetypes.ParamStoreKeyMinGasPrices, minGasPrices)
+	require.False(t, minGasPrices.IsEqual(globalfeetypes.DefaultMinGasPrices))
+
+	// check that the new parameters aren't set
+	_, ok = getBypassMsgTypes(newSubspace, ctx)
+	require.Equal(t, ok, false)
+	_, ok = getMaxTotalBypassMinFeeMsgGasUsage(newSubspace, ctx)
+	require.Equal(t, ok, false)
+
+	// run global fee migration
+	err := v2.MigrateStore(ctx, newSubspace)
+	require.NoError(t, err)
+
+	newMinGasPrices, _ := getMinGasPrice(newSubspace, ctx)
+	bypassMsgTypes, _ := getBypassMsgTypes(newSubspace, ctx)
+	maxGas, _ := getMaxTotalBypassMinFeeMsgGasUsage(newSubspace, ctx)
+
+	require.Equal(t, bypassMsgTypes, globalfeetypes.DefaultBypassMinFeeMsgTypes)
+	require.Equal(t, maxGas, globalfeetypes.DefaultmaxTotalBypassMinFeeMsgGasUsage)
+	require.Equal(t, minGasPrices, newMinGasPrices)
+}
+
+func getBypassMsgTypes(globalfeeSubspace paramtypes.Subspace, ctx sdk.Context) ([]string, bool) {
+	bypassMsgs := []string{}
+	if globalfeeSubspace.Has(ctx, globalfeetypes.ParamStoreKeyBypassMinFeeMsgTypes) {
+		globalfeeSubspace.Get(ctx, globalfeetypes.ParamStoreKeyBypassMinFeeMsgTypes, &bypassMsgs)
+	} else {
+		return bypassMsgs, false
+	}
+
+	return bypassMsgs, true
+}
+
+func getMaxTotalBypassMinFeeMsgGasUsage(globalfeeSubspace paramtypes.Subspace, ctx sdk.Context) (uint64, bool) {
+	var maxTotalBypassMinFeeMsgGasUsage uint64
+	if globalfeeSubspace.Has(ctx, globalfeetypes.ParamStoreKeyMaxTotalBypassMinFeeMsgGasUsage) {
+		globalfeeSubspace.Get(ctx, globalfeetypes.ParamStoreKeyMaxTotalBypassMinFeeMsgGasUsage, &maxTotalBypassMinFeeMsgGasUsage)
+	} else {
+		return maxTotalBypassMinFeeMsgGasUsage, false
+	}
+
+	return maxTotalBypassMinFeeMsgGasUsage, true
+}
+
+func getMinGasPrice(globalfeeSubspace paramtypes.Subspace, ctx sdk.Context) (sdk.DecCoins, bool) {
+	var globalMinGasPrices sdk.DecCoins
+	if globalfeeSubspace.Has(ctx, globalfeetypes.ParamStoreKeyMinGasPrices) {
+		globalfeeSubspace.Get(ctx, globalfeetypes.ParamStoreKeyMinGasPrices, &globalMinGasPrices)
+	} else {
+		return globalMinGasPrices, false
+	}
+
+	return globalMinGasPrices, true
+}


### PR DESCRIPTION
In order to keep maintainability and as a good practice for future module integrations, new modules *must* include migrations.