### PR TITLE
Fix wasmvm SIGABRT regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION="1.22"
-ARG ALPINE_VERSION="3.19"
+ARG ALPINE_VERSION="3.20"
 ARG BUILDPLATFORM=linux/amd64
 ARG BASE_IMAGE="golang:${GO_VERSION}-alpine${ALPINE_VERSION}"
 
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Runner
 # --------------------------------------------------------
 
-FROM alpine:3.19 AS xion-base
+FROM alpine:${ALPINE_VERSION} AS xion-base
 COPY --from=builder /xion/build/xiond /usr/bin/xiond
 
 # api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION="1.22"
-ARG ALPINE_VERSION="3.20"
+ARG ALPINE_VERSION_BUILDER="3.18"
+ARG ALPINE_VERSION_RUNNER="3.19"
 ARG BUILDPLATFORM=linux/amd64
-ARG BASE_IMAGE="golang:${GO_VERSION}-alpine${ALPINE_VERSION}"
+ARG BASE_IMAGE="golang:${GO_VERSION}-alpine${ALPINE_VERSION_BUILDER}"
 
 # --------------------------------------------------------
 # Builder
@@ -43,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Runner
 # --------------------------------------------------------
 
-FROM alpine:${ALPINE_VERSION} AS xion-base
+FROM alpine:${ALPINE_VERSION_RUNNER} AS xion-base
 COPY --from=builder /xion/build/xiond /usr/bin/xiond
 
 # api


### PR DESCRIPTION
Upgrading to golang-1.22 / alpine-3.19 introduced a regression first seen in March and fixed by referring to the version matrix found [here](https://github.com/CosmWasm/wasmvm/issues/523)

Root cause is now fixed in [wasmer-4.3.3](https://github.com/CosmWasm/cosmwasm/pull/2182) / [cosmwasm-2.1.0](https://github.com/CosmWasm/cosmwasm/blob/v2.1.0/CHANGELOG.md)

This change reverts alpine, while we prep cosmwasm.