### PR TITLE
Fix integration inflation test

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -78,6 +78,7 @@ jobs:
           - "DungeonTransferBlock"
           - "XionSendPlatformFee"
           - "MintModuleNoInflationNoFees"
+          - "MintModuleInflationNoFees"
           - "MintModuleInflationHighFees"
           - "MintModuleInflationLowFees"
           - "JWTAbstractAccount"

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,9 @@ test-integration-dungeon-transfer-block: compile_integration_tests
 test-integration-mint-module-no-inflation-no-fees: compile_integration_tests
 	@XION_TEST_IMAGE=$(XION_TEST_IMAGE) ./integration_tests/integration_tests.test -test.failfast -test.v -test.run TestMintModuleNoInflationNoFees
 
+test-integration-mint-module-inflation-no-fees: compile_integration_tests
+	@XION_TEST_IMAGE=$(XION_TEST_IMAGE) ./integration_tests/integration_tests.test -test.failfast -test.v -test.run TestMintModuleInflationNoFees
+
 test-integration-mint-module-inflation-high-fees: compile_integration_tests
 	@XION_TEST_IMAGE=$(XION_TEST_IMAGE) ./integration_tests/integration_tests.test -test.failfast -test.v -test.run TestMintModuleInflationHighFees
 

--- a/integration_tests/mint_test.go
+++ b/integration_tests/mint_test.go
@@ -65,7 +65,7 @@ func TestMintModuleInflationNoFees(t *testing.T) {
 	chainHeight, _ := xion.Height(ctx)
 	testutil.WaitForBlocks(ctx, int(chainHeight)+10, xion)
 	assertion := func(t *testing.T, provision math.LegacyDec, feesAccrued int64, tokenChange int64) {
-		require.Truef(t, provision.TruncateInt().GT(math.NewInt(feesAccrued)), "provision should be greater if tokens where minted")
+		require.Truef(t, provision.TruncateInt().GT(math.NewInt(feesAccrued)), "provision should be greater if tokens where minted, provision: %s, fees accrued:%s", provision.TruncateInt(), feesAccrued)
 		// We have minted tokens because the fees accrued is less than the block provision
 		mintedTokens := provision.TruncateInt().Sub(math.NewInt(feesAccrued))
 		t.Logf("Minted tokens: %d and Token change: %d", mintedTokens.Int64(), int64(tokenChange))


### PR DESCRIPTION
Refactor tests so they don't do a catch all, they should fail if the assertion is incorrect. previous model would catch the scenario and evaluate different criteria