### PR TITLE
Add Typescript Definition Publishing Workflow

### DIFF
--- a/.github/workflows/publish-types-dev.yml
+++ b/.github/workflows/publish-types-dev.yml
@@ -1,0 +1,52 @@
+name: Publish TypeScript Definitions (Dev)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'proto/**'
+      - 'client/ts/types/**'
+
+jobs:
+  publish-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: make proto-deps
+
+      - name: Generate TypeScript definitions
+        run: make proto-gen-ts
+
+      - name: Create package.json for types
+        run: |
+          cat > client/ts/types/package.json << EOF
+          {
+            "name": "@xion/types",
+            "version": "0.0.0-${GITHUB_SHA::8}",
+            "description": "TypeScript definitions for Xion",
+            "types": "index.d.ts",
+            "files": [
+              "**/*.d.ts",
+              "**/*.js"
+            ],
+            "publishConfig": {
+              "access": "public"
+            }
+          }
+          EOF
+
+      - name: Publish to npm
+        run: |
+          cd client/ts/types
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-types-dev.yml
+++ b/.github/workflows/publish-types-dev.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cat > client/ts/types/package.json << EOF
           {
-            "name": "@xion/types",
+            "name": "@burnt-labs/xion-types",
             "version": "0.0.0-${GITHUB_SHA::8}",
             "description": "TypeScript definitions for Xion",
             "types": "index.d.ts",

--- a/.github/workflows/publish-types-release.yml
+++ b/.github/workflows/publish-types-release.yml
@@ -1,0 +1,59 @@
+name: Publish TypeScript Definitions (Release)
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # e.g., v1.2.3, v2.0.0, etc.
+
+jobs:
+  publish-types-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          # GITHUB_REF is usually "refs/tags/v1.2.3"
+          RAW_TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${RAW_TAG#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: make proto-deps
+
+      - name: Generate TypeScript definitions
+        run: make proto-gen-ts
+
+      - name: Create package.json
+        run: |
+          cat > client/ts/types/package.json << EOF
+          {
+            "name": "@xion/types",
+            "version": "${{ env.VERSION }}",
+            "description": "TypeScript definitions for Xion",
+            "types": "index.d.ts",
+            "files": [
+              "**/*.d.ts",
+              "**/*.js"
+            ],
+            "publishConfig": {
+              "access": "public"
+            }
+          }
+          EOF
+
+      - name: Publish to npm
+        run: |
+          cd client/ts/types
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-types-release.yml
+++ b/.github/workflows/publish-types-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cat > client/ts/types/package.json << EOF
           {
-            "name": "@xion/types",
+            "name": "@burnt-labs/xion-types",
             "version": "${{ env.VERSION }}",
             "description": "TypeScript definitions for Xion",
             "types": "index.d.ts",


### PR DESCRIPTION
# TypeScript Types Publishing Workflow

## Summary
Adds an automated GitHub Actions workflow to publish TypeScript type definitions to NPM whenever changes are made to protocol buffers or existing type definitions.

## Changes
- Added new GitHub Action workflow for publishing TypeScript definitions
- Configured workflow to trigger on changes to:
  - `proto/**`
  - `client/ts/types/**` 
- Automatically generates and publishes types to NPM with versioning based on commit SHA
- Ensures types are publicly accessible via NPM registry

## Implementation Details
The workflow:
1. Sets up Node.js 18
2. Installs protocol buffer dependencies
3. Generates TypeScript definitions from proto files
4. Creates a package.json with:
   - Package name: `@xion/types`
   - Version: Using short commit SHA (first 8 chars)
   - Public access configuration
5. Publishes to NPM using repository secrets

## Configuration Required
- `NPM_TOKEN` secret must be configured in repository settings
