### PR TITLE
Fix permissions in Dockerfile

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -67,13 +67,13 @@ jobs:
     uses: burnt-labs/xion/.github/workflows/docker-scout.yaml@workflows/main
     secrets: inherit
 
-  # interchain-tests:
-  #   name: Interchain tests
-  #   needs: 
-  #     - build-docker
-  #     - build-integration
-  #   uses: burnt-labs/xion/.github/workflows/integration-tests.yaml@workflows/main
-  #   secrets: inherit
+  interchain-tests:
+    name: Interchain tests
+    needs: 
+      - build-docker
+      - build-integration
+    uses: burnt-labs/xion/.github/workflows/integration-tests.yaml@workflows/main
+    secrets: inherit
 
   build-release:
     name: Build Release
@@ -83,7 +83,7 @@ jobs:
       - unit-tests
       - build-darwin
       - docker-scout
-      #- interchain-tests
+      - interchain-tests
     uses: burnt-labs/xion/.github/workflows/goreleaser.yaml@workflows/main
     secrets: inherit
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     mkdir -p /go/bin; \
     if [ -e "${PREBUILT_BINARY:-}" ]; then \
         cp -a "${PREBUILT_BINARY}" /go/bin/xiond; \
+        chmod a+x /go/bin/xiond; \
     else \
         goreleaser build \
             --config .goreleaser/build.yaml \
             --snapshot --clean --single-target --skip validate; \
         cp -a $(find ./dist -name xiond-${GOOS}-${GOARCH}) /go/bin/xiond; \
+        chmod a+x /go/bin/xiond; \
     fi;
 
 # --------------------------------------------------------

--- a/client/docs/config.yaml
+++ b/client/docs/config.yaml
@@ -201,13 +201,6 @@ apis:
     tags:
       rename:
         Query: IBC/Core
-  - url: ./packetforward/v1/query.swagger.json
-    operationIds:
-      rename:
-        Params: IBCPacketforwardParams
-    tags:
-      rename:
-        Query: IBC/Core
   - url: ./xion/globalfee/v1/query.swagger.json
     operationIds:
       rename:

--- a/client/ts/package.json
+++ b/client/ts/package.json
@@ -8,7 +8,7 @@
     "types/"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "../../scripts/proto-gen.sh --ts",
     "test": "jest"
   },
   "license": "MIT",

--- a/scripts/proto-gen.sh
+++ b/scripts/proto-gen.sh
@@ -23,25 +23,6 @@ deps=$(cat <<EOF
 EOF
 )
 
-fix=$(cat <<EOF
-{
-  "swagger": "2.0",
-  "info": {
-    "title": "Empty",
-    "version": "0.0.0"
-  },
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
-  "paths": {},
-  "definitions": {}
-}
-EOF
-)
-
 # Install selected dependencies from go.mod
 go mod download $deps
 
@@ -101,10 +82,6 @@ gen_swagger() {
   # combine swagger files
   # uses nodejs package `swagger-combine`.
   # all the individual swagger files need to be configured in `config.json` for merging
-  mkdir -p ${docs_dir}/static
-  # proto does not exist, so create an empty file
-  mkdir -p ${tmp_dir}/packetforward/v1/
-  echo "$fix" > ${tmp_dir}/packetforward/v1/query.swagger.json
   swagger-combine ${docs_dir}/config.yaml \
     --format "json" \
     --output ${docs_dir}/static/swagger.json \


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change ensures that the `xiond` binary has the appropriate executable permissions after being copied to the `/go/bin` directory.

* Added `chmod a+x /go/bin/xiond` to ensure the `xiond` binary is executable after being copied.