### PR TITLE
chore: fix handling of file paths with spaces

### DIFF
--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -13,15 +13,13 @@ fi
 # set ref name if not set
 : ${GITHUB_REF_NAME:=$(git describe --tags)}
 
-binaries=$(
-  find "$release_dir" -name 'xiond_*.zip' ! -name 'xiond_*darwin_all.zip'
-) 
+mapfile -t binaries < <(find "$release_dir" -name 'xiond_*.zip' ! -name 'xiond_*darwin_all.zip')
 
 binaries_list=$(
-  for file in ${binaries[@]}; do
+  for file in "${binaries[@]}"; do
     platform=$(basename "$file" ".zip" | cut -d_ -f3- | sed -E 's/^rc[0-9]*-//g; s/_/\//g')
     checksum=$(sha256sum "$file" | awk '{ print $1 }')
-    echo "\"$platform\": \"https://github.com/burnt-labs/xion/releases/download/${GITHUB_REF_NAME}/$(basename "$file")?checksum=sha256:$checksum"\"
+    echo "\"$platform\": \"https://github.com/burnt-labs/xion/releases/download/${GITHUB_REF_NAME}/$(basename "$file")?checksum=sha256:$checksum\"\"
   done
 )
 


### PR DESCRIPTION
replaced the binaries line with `mapfile` to safely handle file paths with spaces and special characters:

```bash
mapfile -t binaries < <(find "$release_dir" -name 'xiond_*.zip' ! -name 'xiond_*darwin_all.zip')
```

this ensures the script works correctly with any file path.