### PR TITLE
Chore/set commission

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -89,7 +88,10 @@ func (app *WasmApp) V20StakingForceMinimumCommission(ctx context.Context) (err e
 				return true
 			}
 			// SetValidator sets the main record holding validator details
-			app.StakingKeeper.SetValidator(ctx, val)
+			err = app.StakingKeeper.SetValidator(ctx, val)
+			if err != nil {
+				return true
+			}
 		}
 		return false
 	})


### PR DESCRIPTION
This pull request introduces an upgrade mechanism to enforce a minimum commission rate for validators in the staking module during the `v20` upgrade. It includes changes to import necessary dependencies, add a new migration function, and integrate it into the upgrade handler.

### Staking Module Enhancements:
* **Enforce Minimum Commission Rate:** Added the `V20StakingForceMinimumCommission` function to set a minimum commission rate of 0.05 for validators. This function iterates through all validators, updates their commission if it's below the threshold, and ensures the changes are saved. (`app/upgrades.go`, [app/upgrades.goR74-R102](diffhunk://#diff-aeec7ddb4cf8b7e9e6e57625770d369cce5f377cc350b42c3aca0427bba8dfbcR74-R102))

### Upgrade Handler Changes:
* **Integration of Minimum Commission Enforcement:** Updated the `NextUpgradeHandler` to call the `V20StakingForceMinimumCommission` function as part of the module migration process for the `v20` upgrade. (`app/upgrades.go`, [app/upgrades.goR61-R65](diffhunk://#diff-aeec7ddb4cf8b7e9e6e57625770d369cce5f377cc350b42c3aca0427bba8dfbcR61-R65))

### Dependency Updates:
* **Added Required Imports:** Included `cosmossdk.io/math` and `stakingtypes` to support the new staking logic. (`app/upgrades.go`, [app/upgrades.goR7-R14](diffhunk://#diff-aeec7ddb4cf8b7e9e6e57625770d369cce5f377cc350b42c3aca0427bba8dfbcR7-R14))