### PR TITLE
Update broken globalfee module doc link to current location

### DIFF
--- a/x/globalfee/README.md
+++ b/x/globalfee/README.md
@@ -2,4 +2,4 @@
 
 The Global fee module is based on [Gaia's implementation](https://github.com/cosmos/gaia). Whitch is supplied by the great folks at [TGrade](https://github.com/confio/tgrade) 👋, with minor modifications. All credits and big thanks go to the original authors.
 
-More information about Cosmoshub fee system please check [here](https://github.com/cosmos/gaia/blob/main/docs/modules/globalfee.md).
+More information about Cosmoshub fee system please check [here](https://pkg.go.dev/github.com/cosmos/gaia/v8/x/globalfee).


### PR DESCRIPTION
Replaced the outdated link to the Cosmos Hub globalfee module documentation in x/globalfee/README.md with the current, working URL pointing to the GoDoc page for the module. This ensures users can access up-to-date information about the globalfee module implementation and usage.