### PR TITLE
setup for v22

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
-const UpgradeName = "v21"
+const UpgradeName = "v22"
 
 func (app *WasmApp) RegisterUpgradeHandlers() {
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()

--- a/client/docs/config.yaml
+++ b/client/docs/config.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   title: XION - gRPC Gateway docs
   description: A REST interface for state queries
-  version: v21.0.0
+  version: v22.0.0
 apis:
   - url: ./cosmos/auth/v1beta1/query.swagger.json
     operationIds:

--- a/client/docs/static/openapi.json
+++ b/client/docs/static/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "XION - gRPC Gateway docs",
         "description": "A REST interface for state queries",
-        "version": "v21.0.0"
+        "version": "v22.0.0"
     },
     "paths": {
         "/cosmos/auth/v1beta1/account_info/{address}": {

--- a/client/docs/static/swagger.json
+++ b/client/docs/static/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "XION - gRPC Gateway docs",
     "description": "A REST interface for state queries",
-    "version": "v21.0.0"
+    "version": "v22.0.0"
   },
   "paths": {
     "/cosmos/auth/v1beta1/account_info/{address}": {


### PR DESCRIPTION
This pull request updates the project version from v21.0.0 to v22.0.0 across the codebase and documentation to reflect the new release. The most important changes are grouped below:

Version bump and upgrade handler:

* Updated the `UpgradeName` constant in `app/upgrades.go` from `"v21"` to `"v22"` to prepare for the new upgrade cycle.

Documentation updates:

* Updated the API version in `client/docs/config.yaml` from `v21.0.0` to `v22.0.0` to match the new release.
* Updated the version in `client/docs/static/openapi.json` from `v21.0.0` to `v22.0.0`.
* Updated the version in `client/docs/static/swagger.json` from `v21.0.0` to `v22.0.0`.