### PR TITLE
Fix/jwk validate

### DIFF
--- a/x/jwk/keeper/query_test.go
+++ b/x/jwk/keeper/query_test.go
@@ -1047,3 +1047,54 @@ func TestQueryValidateJWTGeneratedSuccess(t *testing.T) {
 
 	t.Log("Successfully validated generated JWT and processed private claims - 100% ValidateJWT coverage achieved!")
 }
+
+// Regression test: non-string private claims should not panic and must be returned stringified
+func TestValidateJWT_NonStringPrivateClaim_NoPanic(t *testing.T) {
+	k, ctx := setupKeeper(t)
+
+	admin := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
+	// Use HMAC for simplicity
+	secretKey := []byte("secret-json-claim")
+	key, err := jwk.FromRaw(secretKey)
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.AlgorithmKey, jwa.HS256))
+	keyJSON, err := json.Marshal(key)
+	require.NoError(t, err)
+
+	aud := types.Audience{Aud: "object-claim-aud", Admin: admin, Key: string(keyJSON)}
+	k.SetAudience(ctx, aud)
+
+	// Build a token with a nested object claim
+	builder := jwt.NewBuilder().
+		Audience([]string{"object-claim-aud"}).
+		Subject("user-1").
+		Expiration(time.Unix(9999999999, 0)).
+		Claim("boom", map[string]interface{}{"nested": "object"})
+
+	tok, err := builder.Build()
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256, secretKey))
+	require.NoError(t, err)
+
+	// Call ValidateJWT; previously this would panic on non-string claim
+	resp, err := k.ValidateJWT(ctx, &types.QueryValidateJWTRequest{
+		Aud:      "object-claim-aud",
+		Sub:      "user-1",
+		SigBytes: string(signed),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.PrivateClaims)
+
+	// Ensure boom claim exists and is JSON stringified
+	found := false
+	for _, pc := range resp.PrivateClaims {
+		if pc.Key == "boom" {
+			found = true
+			require.Contains(t, pc.Value, "\"nested\":\"object\"")
+		}
+	}
+	require.True(t, found, "expected boom claim in private claims")
+}

--- a/x/jwk/keeper/query_validate_jwt.go
+++ b/x/jwk/keeper/query_validate_jwt.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"sort"
 	"time"
 
@@ -75,9 +77,27 @@ func (k Keeper) ValidateJWT(goCtx context.Context, req *types.QueryValidateJWTRe
 
 	i := 0
 	for k, v := range privateClaimsMap {
+		var valStr string
+		switch c := v.(type) {
+		case string:
+			valStr = c
+		case fmt.Stringer:
+			valStr = c.String()
+		case []byte:
+			valStr = string(c)
+		case float64, float32, int, int32, int64, uint, uint32, uint64, bool:
+			valStr = fmt.Sprintf("%v", c)
+		default:
+			if b, mErr := json.Marshal(v); mErr == nil {
+				valStr = string(b)
+			} else {
+				// Fallback to fmt if JSON marshaling fails
+				valStr = fmt.Sprintf("%v", v)
+			}
+		}
 		privateClaims[i] = &types.PrivateClaim{
 			Key:   k,
-			Value: v.(string),
+			Value: valStr,
 		}
 		i++
 	}


### PR DESCRIPTION
This pull request updates the codebase and documentation for the next major release (v22) and improves JWT claim handling to prevent panics and ensure robust claim processing. The most important changes are grouped below:

## Version Upgrade

* Updated the upgrade name constant in `app/upgrades.go` from `v21` to `v22` to reflect the new release version.
* Updated API documentation version to `v22.0.0` in `client/docs/config.yaml`, `client/docs/static/openapi.json`, and `client/docs/static/swagger.json`. [[1]](diffhunk://#diff-f8c6defcc262f9da2d31c779a3bf423772af16800e312eb9f0ef4fb861688252L5-R5) [[2]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL6-R6) [[3]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL6-R6)

## JWT Claim Handling Improvements

* Enhanced the JWT validation logic in `x/jwk/keeper/query_validate_jwt.go` to robustly handle non-string private claims: now all claim values are stringified using type checks, JSON marshaling, or fallback formatting, preventing panics and ensuring claims are returned as strings.
* Added a regression test in `x/jwk/keeper/query_test.go` to verify that non-string private claims do not cause panics and are properly stringified in JWT validation responses.
* Added necessary imports for JSON and formatting in `x/jwk/keeper/query_validate_jwt.go` to support the improved claim stringification logic.