### PR TITLE
Implements the CLI command for deleting audience claims that was missing

### DIFF
--- a/x/jwk/client/cli/cli_test.go
+++ b/x/jwk/client/cli/cli_test.go
@@ -68,6 +68,7 @@ func TestCommandMetadata(t *testing.T) {
 		{"update-audience", cli.CmdUpdateAudience()},
 		{"delete-audience", cli.CmdDeleteAudience()},
 		{"create-audience-claim", cli.CmdCreateAudienceClaim()},
+		{"delete-audience-claim", cli.CmdDeleteAudienceClaim()},
 		{"convert-pem", cli.CmdConvertPemToJSON()},
 	}
 	for _, m := range meta {
@@ -100,6 +101,8 @@ func TestArgumentValidation_Table(t *testing.T) {
 		{"delete audience ok (no ctx)", cli.CmdDeleteAudience, []string{"aud"}, true},
 		{"claim audience missing", cli.CmdCreateAudienceClaim, []string{}, true},
 		{"claim audience ok (no ctx)", cli.CmdCreateAudienceClaim, []string{"aud"}, true},
+		{"delete claim missing", cli.CmdDeleteAudienceClaim, []string{}, true},
+		{"delete claim ok (no ctx)", cli.CmdDeleteAudienceClaim, []string{"aud"}, true},
 		{"convert pem missing", cli.CmdConvertPemToJSON, []string{}, true},
 	}
 	for _, tc := range tests {
@@ -173,6 +176,7 @@ func TestAudienceTxCommands(t *testing.T) {
 		{"update with flags", cli.CmdUpdateAudience(), []string{"aud", "newkey", "--new-admin", "cosmos1bad", "--new-aud", "aud2"}},
 		{"delete audience", cli.CmdDeleteAudience(), []string{"aud"}},
 		{"create claim", cli.CmdCreateAudienceClaim(), []string{"aud"}},
+		{"delete claim", cli.CmdDeleteAudienceClaim(), []string{"aud"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -375,6 +379,20 @@ func TestCreateAudienceClaimVariants(t *testing.T) {
 
 	// With empty context
 	_, err = clitestutil.ExecTestCLICmd(empty, cli.CmdCreateAudienceClaim(), []string{"test-aud"})
+	require.Error(t, err)
+}
+
+func TestDeleteAudienceClaimVariants(t *testing.T) {
+	ctx := newMockCtx(t)
+	empty := newEmptyCtx()
+
+	// With mock context - should error due to validation
+	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDeleteAudienceClaim(), []string{"test-aud"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid admin address")
+
+	// With empty context
+	_, err = clitestutil.ExecTestCLICmd(empty, cli.CmdDeleteAudienceClaim(), []string{"test-aud"})
 	require.Error(t, err)
 }
 

--- a/x/jwk/client/cli/tx.go
+++ b/x/jwk/client/cli/tx.go
@@ -28,6 +28,7 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(CmdCreateAudience())
 	cmd.AddCommand(CmdUpdateAudience())
 	cmd.AddCommand(CmdDeleteAudience())
+	cmd.AddCommand(CmdDeleteAudienceClaim())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/jwk/client/cli/tx_audience.go
+++ b/x/jwk/client/cli/tx_audience.go
@@ -166,3 +166,31 @@ func CmdDeleteAudience() *cobra.Command {
 
 	return cmd
 }
+
+func CmdDeleteAudienceClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete-audience-claim [aud]",
+		Short: "Delete an audience claim",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			audStr := args[0]
+
+			audHash := sha256.Sum256([]byte(audStr))
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgDeleteAudienceClaim(clientCtx.GetFromAddress(), audHash[:])
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}


### PR DESCRIPTION

This pull request adds support for deleting audience claims via the CLI, along with comprehensive test coverage for the new command. The main changes include introducing the `CmdDeleteAudienceClaim` command, updating the transaction command registry, and extending the test suite to validate argument handling and command behavior.

### New CLI command for deleting audience claims
* Added `CmdDeleteAudienceClaim` function to `tx_audience.go`, allowing users to delete an audience claim by specifying the audience identifier. The implementation includes argument validation, message creation, and transaction broadcasting.

### Command registration
* Registered the new `delete-audience-claim` command in the transaction command group within `tx.go`, making it available in the CLI tool.

### Test coverage for delete audience claim command

* Added tests to verify command metadata and argument validation for `delete-audience-claim` in `cli_test.go`. This ensures correct command registration and error handling for missing or invalid arguments. [[1]](diffhunk://#diff-1d46efd4214a00ca13fb864da98971023efe6340b390a9524cbb4b93f9d23833R71) [[2]](diffhunk://#diff-1d46efd4214a00ca13fb864da98971023efe6340b390a9524cbb4b93f9d23833R104-R105)
* Extended transaction command tests to include scenarios for deleting audience claims, verifying integration with the CLI.
* Added a new test function, `TestDeleteAudienceClaimVariants`, to cover validation errors and context handling for the delete audience claim command.