### PR TITLE
fix integer overflow vulnerability in platform fee calculation

### DIFF
--- a/x/xion/keeper/msg_server.go
+++ b/x/xion/keeper/msg_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/hashicorp/go-metrics"
 
@@ -63,7 +64,29 @@ func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSe
 	}
 
 	if !percentage.IsZero() {
-		platformCoins := msg.Amount.MulInt(percentage).QuoInt(math.NewInt(10000))
+		// Safe calculation to prevent overflow: use multiplication with bounds checking
+		// For each coin, calculate: (amount * percentage) / 10000
+		// But prevent overflow by checking if amount * percentage would overflow
+		var platformCoins sdk.Coins
+		for _, coin := range msg.Amount {
+			// Check if multiplication would overflow by comparing with MaxUint64/percentage
+			maxSafeAmount := math.NewIntFromUint64(^uint64(0)).Quo(percentage)
+			if coin.Amount.GT(maxSafeAmount) {
+				// Use big integer arithmetic to prevent overflow
+				bigAmount := coin.Amount.BigInt()
+				bigPercentage := percentage.BigInt()
+				bigDivisor := math.NewInt(10000).BigInt()
+				
+				bigResult := new(big.Int).Mul(bigAmount, bigPercentage)
+				bigResult = bigResult.Quo(bigResult, bigDivisor)
+				
+				platformCoins = platformCoins.Add(sdk.NewCoin(coin.Denom, math.NewIntFromBigInt(bigResult)))
+			} else {
+				// Safe to use normal calculation
+				feeAmount := coin.Amount.Mul(percentage).Quo(math.NewInt(10000))
+				platformCoins = platformCoins.Add(sdk.NewCoin(coin.Denom, feeAmount))
+			}
+		}
 		throughCoins = throughCoins.Sub(platformCoins...)
 
 		if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, from, authtypes.FeeCollectorName, platformCoins); err != nil {
@@ -123,7 +146,27 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 
 		// if there is a platform fee set, reduce it from each output
 		if !percentage.IsZero() {
-			platformCoins := out.Coins.MulInt(percentage).QuoInt(math.NewInt(10000))
+			// Safe calculation to prevent overflow: use multiplication with bounds checking
+			var platformCoins sdk.Coins
+			for _, coin := range out.Coins {
+				// Check if multiplication would overflow by comparing with MaxUint64/percentage
+				maxSafeAmount := math.NewIntFromUint64(^uint64(0)).Quo(percentage)
+				if coin.Amount.GT(maxSafeAmount) {
+					// Use big integer arithmetic to prevent overflow
+					bigAmount := coin.Amount.BigInt()
+					bigPercentage := percentage.BigInt()
+					bigDivisor := math.NewInt(10000).BigInt()
+					
+					bigResult := new(big.Int).Mul(bigAmount, bigPercentage)
+					bigResult = bigResult.Quo(bigResult, bigDivisor)
+					
+					platformCoins = platformCoins.Add(sdk.NewCoin(coin.Denom, math.NewIntFromBigInt(bigResult)))
+				} else {
+					// Safe to use normal calculation
+					feeAmount := coin.Amount.Mul(percentage).Quo(math.NewInt(10000))
+					platformCoins = platformCoins.Add(sdk.NewCoin(coin.Denom, feeAmount))
+				}
+			}
 			throughCoins, wentNegative := out.Coins.SafeSub(platformCoins...)
 			if wentNegative {
 				return nil, fmt.Errorf("unable to subtract %v from %v", platformCoins, throughCoins)

--- a/x/xion/keeper/msg_server.go
+++ b/x/xion/keeper/msg_server.go
@@ -76,10 +76,10 @@ func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSe
 				bigAmount := coin.Amount.BigInt()
 				bigPercentage := percentage.BigInt()
 				bigDivisor := math.NewInt(10000).BigInt()
-				
+
 				bigResult := new(big.Int).Mul(bigAmount, bigPercentage)
 				bigResult = bigResult.Quo(bigResult, bigDivisor)
-				
+
 				platformCoins = platformCoins.Add(sdk.NewCoin(coin.Denom, math.NewIntFromBigInt(bigResult)))
 			} else {
 				// Safe to use normal calculation
@@ -156,10 +156,10 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 					bigAmount := coin.Amount.BigInt()
 					bigPercentage := percentage.BigInt()
 					bigDivisor := math.NewInt(10000).BigInt()
-					
+
 					bigResult := new(big.Int).Mul(bigAmount, bigPercentage)
 					bigResult = bigResult.Quo(bigResult, bigDivisor)
-					
+
 					platformCoins = platformCoins.Add(sdk.NewCoin(coin.Denom, math.NewIntFromBigInt(bigResult)))
 				} else {
 					// Safe to use normal calculation

--- a/x/xion/keeper/msg_server_test.go
+++ b/x/xion/keeper/msg_server_test.go
@@ -637,4 +637,3 @@ func TestMsgServer_MultiSend_HighPlatformFee(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, response)
 }
-

--- a/x/xion/keeper/msg_server_test.go
+++ b/x/xion/keeper/msg_server_test.go
@@ -637,3 +637,4 @@ func TestMsgServer_MultiSend_HighPlatformFee(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, response)
 }
+


### PR DESCRIPTION
This pull request improves the handling of platform fee calculations in the `msg_server.go` file by introducing overflow-safe arithmetic. The main enhancement is the use of big integer math to prevent overflow when calculating platform fees for large coin amounts, ensuring correct and safe fee deduction.

**Overflow-safe platform fee calculation:**

* Updated the platform fee calculation logic in both the `Send` and `MultiSend` message handlers to use big integer arithmetic when coin amounts are too large for standard multiplication, preventing overflow and ensuring accurate fee computation. [[1]](diffhunk://#diff-b026d8897e6cc60e07d9c7e1ca5a374301fbb719566e546a86d9917c4f84b32bL66-R89) [[2]](diffhunk://#diff-b026d8897e6cc60e07d9c7e1ca5a374301fbb719566e546a86d9917c4f84b32bL126-R169)
* Added import of the `math/big` package to support big integer operations for fee calculations.

**Testing:**

* Minor formatting change in the `TestMsgServer_MultiSend_HighPlatformFee` test to maintain code style consistency.