### PR TITLE
limit ibc hops to 10

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -788,7 +788,7 @@ func NewWasmApp(
 	transferStack = packetforward.NewIBCMiddleware(
 		cbStack,
 		app.PacketForwardKeeper,
-		0,
+		10,
 		packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
 	)
 


### PR DESCRIPTION
Fix: Set reasonable IBC packet forwarding hop limit
Problem: XION's IBC packet forwarding middleware was configured with a hop limit of 0, which allows unlimited hops in multi-hop IBC transfers. While not a critical vulnerability (due to built-in IBC timeout protections), this configuration could allow unnecessarily long forwarding chains that consume more network resources than needed.

Solution: Set the hop limit to 10 in the packet forwarding middleware configuration. This provides:

✅ Sufficient hops for virtually all legitimate multi-hop IBC transfer scenarios
✅ Reasonable resource protection against excessively long forwarding chains
✅ Clear operational boundaries for packet forwarding
✅ Following security best practices for resource management
Changes:

No breaking changes - 10 hops is more than adequate for normal multi-hop transfers
Improved resource management and operational clarity
Better defense against potential misuse of the forwarding system
Testing: Existing IBC integration tests continue to pass, confirming no functional impact on normal operations.