### PR TITLE
Fix : file name mismatch for goreleaser.yaml

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -85,7 +85,7 @@ jobs:
       - build-darwin
       - docker-scout
       - interchain-tests
-    uses: burnt-labs/xion/.github/workflows/goreleaser.yaml@workflows/main
+    uses: burnt-labs/xion/.github/workflows/exec-goreleaser.yaml@workflows/main
     secrets: inherit
 
   # TODO: move to goreleaser


### PR DESCRIPTION
Fixed the name difference in the build-release step in create-release.yaml
It needs to be https://github.com/burnt-labs/xion/blob/workflows/main/.github/workflows/exec-goreleaser.yaml

Check the failed run : https://github.com/burnt-labs/xion/actions/runs/17915984497
