### PR TITLE
add codecs

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -34,39 +34,39 @@ jobs:
         os: [linux]
         arch: [amd64]
         test:
-          - { dir: "abstract-account", type: "AA" }
-          - { dir: "app", type: "AppGenesisExportImport" }
-          - { dir: "app", type: "AppGovernance" }
-          - { dir: "app", type: "AppMint" }
-          - { dir: "app", type: "AppSendPlatformFee" }
-          - { dir: "app", type: "AppSimulate" }
-          - { dir: "app", type: "AppTokenFactory" }
-          - { dir: "app", type: "AppTreasury" }
-          - { dir: "app", type: "AppUpdateTreasury" }
-          - { dir: "app", type: "AppUpgradeNetwork$" }
-          - { dir: "dkim", type: "DKIMModule" }
-          - { dir: "dkim", type: "DKIMGovernance" }
-          - { dir: "dkim", type: "DKIMPubKeyMaxSize" }
-          - { dir: "dkim", type: "DKIMRevokedKeyCannotBeReadded" }
-          - { dir: "indexer", type: "IndexerAuthz" }
-          - { dir: "indexer", type: "IndexerFeeGrant" }
-          - { dir: "indexer", type: "IndexerNonConsensusCritical" }
+          - {dir: "abstract-account", type: "AA"}
+          - {dir: "app", type: "AppGenesisExportImport"}
+          - {dir: "app", type: "AppGovernance"}
+          - {dir: "app", type: "AppMint"}
+          - {dir: "app", type: "AppSendPlatformFee"}
+          - {dir: "app", type: "AppSimulate"}
+          - {dir: "app", type: "AppTokenFactory"}
+          - {dir: "app", type: "AppTreasury"}
+          - {dir: "app", type: "AppUpdateTreasury"}
+          - {dir: "app", type: "AppUpgradeNetwork$"}
+          - {dir: "dkim", type: "DKIMModule"}
+          - {dir: "dkim", type: "DKIMGovernance"}
+          - {dir: "dkim", type: "DKIMPubKeyMaxSize"}
+          - {dir: "dkim", type: "DKIMRevokedKeyCannotBeReadded"}
+          - {dir: "indexer", type: "IndexerAuthz"}
+          - {dir: "indexer", type: "IndexerFeeGrant"}
+          - {dir: "indexer", type: "IndexerNonConsensusCritical"}
           # - {dir: "ibc", type: "IBC"}
-          - { dir: "ibc", type: "IBCMinFeeMultiDenom" }
-          - { dir: "jwk", type: "JWK" }
-          - { dir: "xion", type: "XionMinFeeDefault" }
-          - { dir: "xion", type: "XionMinFeeZero" }
-          - { dir: "xion", type: "XionMinFeeMultiDenom" }
-          - { dir: "xion", type: "XionMinFeeBypass" }
-          - { dir: "xion", type: "XionMinFeeConcurrent" }
-          - { dir: "xion", type: "XionMinFeeError" }
-          - { dir: "xion", type: "XionMinFeeExtreme" }
-          - { dir: "xion", type: "XionMinFeeFeeGrant" }
-          - { dir: "xion", type: "XionMinFeeGasCap" }
-          - { dir: "xion", type: "XionMinFeeMemPool" }
-          - { dir: "xion", type: "XionMinFeeMultiMessage" }
-          - { dir: "xion", type: "XionPlatform" }
-          - { dir: "zk", type: "ZK" }
+          - {dir: "ibc", type: "IBCMinFeeMultiDenom"}
+          - {dir: "jwk", type: "JWK"}
+          - {dir: "xion", type: "XionMinFeeDefault"}
+          - {dir: "xion", type: "XionMinFeeZero"}
+          - {dir: "xion", type: "XionMinFeeMultiDenom"}
+          - {dir: "xion", type: "XionMinFeeBypass"}
+          - {dir: "xion", type: "XionMinFeeConcurrent"}
+          - {dir: "xion", type: "XionMinFeeError"}
+          - {dir: "xion", type: "XionMinFeeExtreme"}
+          - {dir: "xion", type: "XionMinFeeFeeGrant"}
+          - {dir: "xion", type: "XionMinFeeGasCap"}
+          - {dir: "xion", type: "XionMinFeeMemPool"}
+          - {dir: "xion", type: "XionMinFeeMultiMessage"}
+          - {dir: "xion", type: "XionPlatform"}
+          - {dir: "zk", type: "ZK"}
 
     steps:
       - name: checkout

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -22,11 +22,9 @@ jobs:
     secrets: inherit
   trigger-assets:
     name: Trigger Assets
-    if: github.event.action == 'released'
     uses: ./.github/workflows/trigger-assets.yaml
     secrets: inherit
   trigger-homebrew:
     name: Trigger Homebrew
-    if: github.event.action == 'released'
     uses: ./.github/workflows/trigger-homebrew.yaml
     secrets: inherit

--- a/api/xion/dkim/v1/genesis.pulsar.go
+++ b/api/xion/dkim/v1/genesis.pulsar.go
@@ -1239,7 +1239,8 @@ type Params struct {
 
 	// vkey defines the verification key used by the module.
 	VkeyIdentifier uint64 `protobuf:"varint,1,opt,name=vkey_identifier,json=vkeyIdentifier,proto3" json:"vkey_identifier,omitempty"`
-	// max_pubkey_size_bytes caps the allowed DKIM public key size (base64 decoded).
+	// max_pubkey_size_bytes caps the allowed DKIM public key size (base64
+	// decoded).
 	MaxPubkeySizeBytes uint64 `protobuf:"varint,2,opt,name=max_pubkey_size_bytes,json=maxPubkeySizeBytes,proto3" json:"max_pubkey_size_bytes,omitempty"`
 }
 

--- a/api/xion/dkim/v1/query.pulsar.go
+++ b/api/xion/dkim/v1/query.pulsar.go
@@ -4346,7 +4346,8 @@ func (x *QueryDkimPubKeysResponse) GetPagination() *v1beta1.PageResponse {
 	return nil
 }
 
-// QueryAuthenticateRequest defines the request structure for proof verification.
+// QueryAuthenticateRequest defines the request structure for proof
+// verification.
 type QueryAuthenticateRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/xion/zk/v1/query.pulsar.go
+++ b/api/xion/zk/v1/query.pulsar.go
@@ -8219,15 +8219,20 @@ func (x *SnarkJsProof) GetPiC() [][]byte {
 	return nil
 }
 
+// QueryVerifyRequest is the request type for the Query/ProofVerify RPC method.
 type QueryVerifyRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Proof        []byte   `protobuf:"bytes,1,opt,name=proof,proto3" json:"proof,omitempty"`
+	// proof is the serialized ZK proof to verify.
+	Proof []byte `protobuf:"bytes,1,opt,name=proof,proto3" json:"proof,omitempty"`
+	// public_inputs is the list of public inputs for the proof.
 	PublicInputs []string `protobuf:"bytes,2,rep,name=public_inputs,json=publicInputs,proto3" json:"public_inputs,omitempty"`
-	VkeyName     string   `protobuf:"bytes,3,opt,name=vkey_name,json=vkeyName,proto3" json:"vkey_name,omitempty"`
-	VkeyId       uint64   `protobuf:"varint,4,opt,name=vkey_id,json=vkeyId,proto3" json:"vkey_id,omitempty"`
+	// vkey_name is the name of the verification key to use.
+	VkeyName string `protobuf:"bytes,3,opt,name=vkey_name,json=vkeyName,proto3" json:"vkey_name,omitempty"`
+	// vkey_id is the ID of the verification key to use.
+	VkeyId uint64 `protobuf:"varint,4,opt,name=vkey_id,json=vkeyId,proto3" json:"vkey_id,omitempty"`
 }
 
 func (x *QueryVerifyRequest) Reset() {
@@ -8315,14 +8320,19 @@ func (x *ProofVerifyResponse) GetVerified() bool {
 	return false
 }
 
+// VKey represents a verification key for ZK proof verification.
 type VKey struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	KeyBytes    []byte `protobuf:"bytes,1,opt,name=key_bytes,json=keyBytes,proto3" json:"key_bytes,omitempty"`
-	Name        string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// key_bytes is the raw bytes of the verification key.
+	KeyBytes []byte `protobuf:"bytes,1,opt,name=key_bytes,json=keyBytes,proto3" json:"key_bytes,omitempty"`
+	// name is the unique human-readable identifier for this key.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// description provides additional context about the verification key.
 	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	// circuit_hash is the hash of the circuit this key is associated with.
 	CircuitHash string `protobuf:"bytes,4,opt,name=circuit_hash,json=circuitHash,proto3" json:"circuit_hash,omitempty"`
 	// authority is the uploader of the verification key.
 	Authority string `protobuf:"bytes,5,opt,name=authority,proto3" json:"authority,omitempty"`
@@ -8457,7 +8467,8 @@ func (x *QueryVKeyResponse) GetVkey() *VKey {
 	return nil
 }
 
-// QueryVKeyByNameRequest is the request type for the Query/VKeyByName RPC method
+// QueryVKeyByNameRequest is the request type for the Query/VKeyByName RPC
+// method
 type QueryVKeyByNameRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -8494,7 +8505,8 @@ func (x *QueryVKeyByNameRequest) GetName() string {
 	return ""
 }
 
-// QueryVKeyByNameResponse is the response type for the Query/VKeyByName RPC method
+// QueryVKeyByNameResponse is the response type for the Query/VKeyByName RPC
+// method
 type QueryVKeyByNameResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -8752,7 +8764,8 @@ func (x *QueryHasVKeyResponse) GetId() uint64 {
 	return 0
 }
 
-// QueryNextVKeyIDRequest is the request type for the Query/NextVKeyID RPC method
+// QueryNextVKeyIDRequest is the request type for the Query/NextVKeyID RPC
+// method
 type QueryNextVKeyIDRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -8779,12 +8792,14 @@ func (*QueryNextVKeyIDRequest) Descriptor() ([]byte, []int) {
 	return file_xion_zk_v1_query_proto_rawDescGZIP(), []int{13}
 }
 
-// QueryNextVKeyIDResponse is the response type for the Query/NextVKeyID RPC method
+// QueryNextVKeyIDResponse is the response type for the Query/NextVKeyID RPC
+// method
 type QueryNextVKeyIDResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// next_id is the next available verification key ID.
 	NextId uint64 `protobuf:"varint,1,opt,name=next_id,json=nextId,proto3" json:"next_id,omitempty"`
 }
 

--- a/api/xion/zk/v1/query_grpc.pb.go
+++ b/api/xion/zk/v1/query_grpc.pb.go
@@ -44,6 +44,7 @@ type QueryClient interface {
 	VKeys(ctx context.Context, in *QueryVKeysRequest, opts ...grpc.CallOption) (*QueryVKeysResponse, error)
 	// HasVKey checks if a verification key exists by name
 	HasVKey(ctx context.Context, in *QueryHasVKeyRequest, opts ...grpc.CallOption) (*QueryHasVKeyResponse, error)
+	// NextVKeyID queries the next available verification key ID
 	NextVKeyID(ctx context.Context, in *QueryNextVKeyIDRequest, opts ...grpc.CallOption) (*QueryNextVKeyIDResponse, error)
 	// Params returns zk module parameters.
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
@@ -143,6 +144,7 @@ type QueryServer interface {
 	VKeys(context.Context, *QueryVKeysRequest) (*QueryVKeysResponse, error)
 	// HasVKey checks if a verification key exists by name
 	HasVKey(context.Context, *QueryHasVKeyRequest) (*QueryHasVKeyResponse, error)
+	// NextVKeyID queries the next available verification key ID
 	NextVKeyID(context.Context, *QueryNextVKeyIDRequest) (*QueryNextVKeyIDResponse, error)
 	// Params returns zk module parameters.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)

--- a/client/docs/config.yaml
+++ b/client/docs/config.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   title: XION - gRPC Gateway docs
   description: A REST interface for state queries
-  version: v26.0.0
+  version: v27.0.0
 apis:
   - url: ./cosmos/auth/v1beta1/query.swagger.json
     operationIds:

--- a/client/docs/static/openapi.json
+++ b/client/docs/static/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "XION - gRPC Gateway docs",
         "description": "A REST interface for state queries",
-        "version": "v26.0.0"
+        "version": "v27.0.0"
     },
     "paths": {
         "/cosmos/auth/v1beta1/account_info/{address}": {

--- a/client/docs/static/swagger.json
+++ b/client/docs/static/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "XION - gRPC Gateway docs",
     "description": "A REST interface for state queries",
-    "version": "v26.0.0"
+    "version": "v27.0.0"
   },
   "paths": {
     "/cosmos/auth/v1beta1/account_info/{address}": {

--- a/make/test.mk
+++ b/make/test.mk
@@ -55,10 +55,6 @@ test-run: .ensure-docker-image
 	@echo "Running test: $(TEST_NAME) in directory: $(DIR_NAME)"
 	@cd ./e2e_tests/$(DIR_NAME) && go test -mod=readonly -tags='ledger test_ledger_mock' -ldflags="-w" -failfast -v -timeout 10m -run "$(TEST_NAME)" ./...
 
-test-run-no-time: .ensure-docker-image
-	@echo "Running test: $(TEST_NAME) in directory: $(DIR_NAME)"
-	@cd ./e2e_tests/$(DIR_NAME) && go test -mod=readonly -timeout 60m -tags='ledger test_ledger_mock' -ldflags="-w" -failfast -v -run $(TEST_NAME) ./...
-
 # Abstract Account Module Tests
 test-aa-basic:
 	$(MAKE) test-run DIR_NAME=abstract-account TEST_NAME=TestAABasic

--- a/proto/xion/dkim/v1/genesis.proto
+++ b/proto/xion/dkim/v1/genesis.proto
@@ -27,6 +27,7 @@ message Params {
   // vkey defines the verification key used by the module.
   uint64 vkey_identifier = 1;
 
-  // max_pubkey_size_bytes caps the allowed DKIM public key size (base64 decoded).
+  // max_pubkey_size_bytes caps the allowed DKIM public key size (base64
+  // decoded).
   uint64 max_pubkey_size_bytes = 2;
 }

--- a/proto/xion/dkim/v1/query.proto
+++ b/proto/xion/dkim/v1/query.proto
@@ -69,7 +69,8 @@ message QueryDkimPubKeysResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 3;
 }
 
-// QueryAuthenticateRequest defines the request structure for proof verification.
+// QueryAuthenticateRequest defines the request structure for proof
+// verification.
 message QueryAuthenticateRequest {
   // tx_bytes defines the serialized transaction bytes.
   bytes tx_bytes = 1;

--- a/proto/xion/zk/v1/genesis.proto
+++ b/proto/xion/zk/v1/genesis.proto
@@ -10,8 +10,7 @@ import "gogoproto/gogo.proto";
 // GenesisState defines the zk module's genesis state.
 message GenesisState {
   // vkeys is the list of all verification keys with their IDs
-  repeated VKeyWithID vkeys = 1 [(gogoproto.nullable) = false];
+  repeated VKeyWithID vkeys = 1 [ (gogoproto.nullable) = false ];
   // params defines the module parameters.
-  Params params = 2 [(gogoproto.nullable) = false];
+  Params params = 2 [ (gogoproto.nullable) = false ];
 }
-

--- a/proto/xion/zk/v1/query.proto
+++ b/proto/xion/zk/v1/query.proto
@@ -14,7 +14,7 @@ service Query {
   rpc ProofVerify(QueryVerifyRequest) returns (ProofVerifyResponse) {
     option (google.api.http).get = "/zk/v1/verify";
   }
-    // VKey queries a verification key by ID
+  // VKey queries a verification key by ID
   rpc VKey(QueryVKeyRequest) returns (QueryVKeyResponse) {
     option (google.api.http).get = "/burnt/xion/zk/v1/vkeys/{id}";
   }
@@ -33,6 +33,8 @@ service Query {
   rpc HasVKey(QueryHasVKeyRequest) returns (QueryHasVKeyResponse) {
     option (google.api.http).get = "/burnt/xion/zk/v1/vkeys/exists/{name}";
   }
+
+  // NextVKeyID queries the next available verification key ID
   rpc NextVKeyID(QueryNextVKeyIDRequest) returns (QueryNextVKeyIDResponse) {
     option (google.api.http).get = "/burnt/xion/zk/v1/vkeys/next-id";
   }
@@ -53,10 +55,15 @@ message SnarkJsProof {
   repeated bytes pi_c = 3;
 }
 
+// QueryVerifyRequest is the request type for the Query/ProofVerify RPC method.
 message QueryVerifyRequest {
+  // proof is the serialized ZK proof to verify.
   bytes proof = 1;
+  // public_inputs is the list of public inputs for the proof.
   repeated string public_inputs = 2;
+  // vkey_name is the name of the verification key to use.
   string vkey_name = 3;
+  // vkey_id is the ID of the verification key to use.
   uint64 vkey_id = 4;
 }
 // ProofVerifyResponse defines the response structure for proof verification.
@@ -65,15 +72,19 @@ message ProofVerifyResponse {
   bool verified = 1;
 }
 
+// VKey represents a verification key for ZK proof verification.
 message VKey {
+  // key_bytes is the raw bytes of the verification key.
   bytes key_bytes = 1;
+  // name is the unique human-readable identifier for this key.
   string name = 2;
+  // description provides additional context about the verification key.
   string description = 3;
+  // circuit_hash is the hash of the circuit this key is associated with.
   string circuit_hash = 4;
   // authority is the uploader of the verification key.
   string authority = 5;
 }
-
 
 // QueryVKeyRequest is the request type for the Query/VKey RPC method
 message QueryVKeyRequest {
@@ -84,20 +95,22 @@ message QueryVKeyRequest {
 // QueryVKeyResponse is the response type for the Query/VKey RPC method
 message QueryVKeyResponse {
   // vkey is the verification key
-  VKey vkey = 1 [(gogoproto.nullable) = false];
+  VKey vkey = 1 [ (gogoproto.nullable) = false ];
 }
 
-// QueryVKeyByNameRequest is the request type for the Query/VKeyByName RPC method
+// QueryVKeyByNameRequest is the request type for the Query/VKeyByName RPC
+// method
 message QueryVKeyByNameRequest {
   // name is the unique name of the verification key
   string name = 1;
 }
 
-// QueryVKeyByNameResponse is the response type for the Query/VKeyByName RPC method
+// QueryVKeyByNameResponse is the response type for the Query/VKeyByName RPC
+// method
 message QueryVKeyByNameResponse {
   // vkey is the verification key
-  VKey vkey = 1 [(gogoproto.nullable) = false];
-  
+  VKey vkey = 1 [ (gogoproto.nullable) = false ];
+
   // id is the numeric identifier of the verification key
   uint64 id = 2;
 }
@@ -111,8 +124,8 @@ message QueryVKeysRequest {
 // QueryVKeysResponse is the response type for the Query/VKeys RPC method
 message QueryVKeysResponse {
   // vkeys is the list of all verification keys with their IDs
-  repeated VKeyWithID vkeys = 1 [(gogoproto.nullable) = false];
-  
+  repeated VKeyWithID vkeys = 1 [ (gogoproto.nullable) = false ];
+
   // pagination defines the pagination in the response
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -121,9 +134,9 @@ message QueryVKeysResponse {
 message VKeyWithID {
   // id is the unique identifier
   uint64 id = 1;
-  
+
   // vkey is the verification key
-  VKey vkey = 2 [(gogoproto.nullable) = false];
+  VKey vkey = 2 [ (gogoproto.nullable) = false ];
 }
 
 // QueryHasVKeyRequest is the request type for the Query/HasVKey RPC method
@@ -136,16 +149,19 @@ message QueryHasVKeyRequest {
 message QueryHasVKeyResponse {
   // exists indicates whether the verification key exists
   bool exists = 1;
-  
+
   // id is the numeric identifier if the key exists (0 if not found)
   uint64 id = 2;
 }
 
-// QueryNextVKeyIDRequest is the request type for the Query/NextVKeyID RPC method
+// QueryNextVKeyIDRequest is the request type for the Query/NextVKeyID RPC
+// method
 message QueryNextVKeyIDRequest {}
 
-// QueryNextVKeyIDResponse is the response type for the Query/NextVKeyID RPC method
+// QueryNextVKeyIDResponse is the response type for the Query/NextVKeyID RPC
+// method
 message QueryNextVKeyIDResponse {
+  // next_id is the next available verification key ID.
   uint64 next_id = 1;
 }
 
@@ -155,5 +171,5 @@ message QueryParamsRequest {}
 // QueryParamsResponse is the response type for the Query/Params RPC method
 message QueryParamsResponse {
   // params is the current zk module parameters
-  Params params = 1 [(gogoproto.nullable) = false];
+  Params params = 1 [ (gogoproto.nullable) = false ];
 }

--- a/proto/xion/zk/v1/tx.proto
+++ b/proto/xion/zk/v1/tx.proto
@@ -32,7 +32,7 @@ message MsgAddVKey {
   option (amino.name) = "zk/MsgAddVKey";
 
   // authority is the address that controls the module (governance)
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
 
   // name is the unique identifier for this verification key
   string name = 2;
@@ -56,7 +56,7 @@ message MsgUpdateVKey {
   option (amino.name) = "zk/MsgUpdateVKey";
 
   // authority is the address that controls the module (governance)
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
 
   // name is the identifier of the verification key to update
   string name = 2;
@@ -77,7 +77,7 @@ message MsgRemoveVKey {
   option (amino.name) = "zk/MsgRemoveVKey";
 
   // authority is the address that controls the module (governance)
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
 
   // name is the identifier of the verification key to remove
   string name = 2;

--- a/x/dkim/types/codec.go
+++ b/x/dkim/types/codec.go
@@ -2,17 +2,27 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
+var amino = codec.NewLegacyAmino()
+
+func init() {
+	RegisterLegacyAminoCodec(amino)
+	cryptocodec.RegisterCrypto(amino)
+	sdk.RegisterLegacyAminoCodec(amino)
+}
+
 // RegisterLegacyAminoCodec registers concrete types on the LegacyAmino codec
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgAddDkimPubKeys{}, ModuleName+"/MsgAddDkimPubKey", nil)
-	cdc.RegisterConcrete(&MsgRemoveDkimPubKey{}, ModuleName+"/MsgRemoveDkimPubKey", nil)
-	cdc.RegisterConcrete(&MsgRevokeDkimPubKey{}, ModuleName+"/MsgRevokeDkimPubKey", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, ModuleName+"/MsgUpdateParams", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgAddDkimPubKeys{}, ModuleName+"/MsgAddDkimPubKeys")
+	legacy.RegisterAminoMsg(cdc, &MsgRemoveDkimPubKey{}, ModuleName+"/MsgRemoveDkimPubKey")
+	legacy.RegisterAminoMsg(cdc, &MsgRevokeDkimPubKey{}, ModuleName+"/MsgRevokeDkimPubKey")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, ModuleName+"/MsgUpdateParams")
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/dkim/types/genesis.pb.go
+++ b/x/dkim/types/genesis.pb.go
@@ -92,7 +92,8 @@ func (m *GenesisState) GetRevokedPubkeys() []string {
 type Params struct {
 	// vkey defines the verification key used by the module.
 	VkeyIdentifier uint64 `protobuf:"varint,1,opt,name=vkey_identifier,json=vkeyIdentifier,proto3" json:"vkey_identifier,omitempty"`
-	// max_pubkey_size_bytes caps the allowed DKIM public key size (base64 decoded).
+	// max_pubkey_size_bytes caps the allowed DKIM public key size (base64
+	// decoded).
 	MaxPubkeySizeBytes uint64 `protobuf:"varint,2,opt,name=max_pubkey_size_bytes,json=maxPubkeySizeBytes,proto3" json:"max_pubkey_size_bytes,omitempty"`
 }
 

--- a/x/dkim/types/query.pb.go
+++ b/x/dkim/types/query.pb.go
@@ -262,7 +262,8 @@ func (m *QueryDkimPubKeysResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
-// QueryAuthenticateRequest defines the request structure for proof verification.
+// QueryAuthenticateRequest defines the request structure for proof
+// verification.
 type QueryAuthenticateRequest struct {
 	// tx_bytes defines the serialized transaction bytes.
 	TxBytes []byte `protobuf:"bytes,1,opt,name=tx_bytes,json=txBytes,proto3" json:"tx_bytes,omitempty"`

--- a/x/zk/types/codec.go
+++ b/x/zk/types/codec.go
@@ -2,18 +2,28 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
+var amino = codec.NewLegacyAmino()
+
+func init() {
+	RegisterLegacyAminoCodec(amino)
+	cryptocodec.RegisterCrypto(amino)
+	sdk.RegisterLegacyAminoCodec(amino)
+}
+
 // RegisterLegacyAminoCodec registers the necessary x/zk interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgAddVKey{}, "zk/MsgAddVKey", nil)
-	cdc.RegisterConcrete(&MsgUpdateVKey{}, "zk/MsgUpdateVKey", nil)
-	cdc.RegisterConcrete(&MsgRemoveVKey{}, "zk/MsgRemoveVKey", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, "zk/MsgUpdateParams", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgAddVKey{}, "zk/MsgAddVKey")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateVKey{}, "zk/MsgUpdateVKey")
+	legacy.RegisterAminoMsg(cdc, &MsgRemoveVKey{}, "zk/MsgRemoveVKey")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "zk/MsgUpdateParams")
 }
 
 // RegisterInterfaces registers the x/zk interfaces types with the interface registry

--- a/x/zk/types/query.pb.go
+++ b/x/zk/types/query.pb.go
@@ -94,11 +94,16 @@ func (m *SnarkJsProof) GetPiC() [][]byte {
 	return nil
 }
 
+// QueryVerifyRequest is the request type for the Query/ProofVerify RPC method.
 type QueryVerifyRequest struct {
-	Proof        []byte   `protobuf:"bytes,1,opt,name=proof,proto3" json:"proof,omitempty"`
+	// proof is the serialized ZK proof to verify.
+	Proof []byte `protobuf:"bytes,1,opt,name=proof,proto3" json:"proof,omitempty"`
+	// public_inputs is the list of public inputs for the proof.
 	PublicInputs []string `protobuf:"bytes,2,rep,name=public_inputs,json=publicInputs,proto3" json:"public_inputs,omitempty"`
-	VkeyName     string   `protobuf:"bytes,3,opt,name=vkey_name,json=vkeyName,proto3" json:"vkey_name,omitempty"`
-	VkeyId       uint64   `protobuf:"varint,4,opt,name=vkey_id,json=vkeyId,proto3" json:"vkey_id,omitempty"`
+	// vkey_name is the name of the verification key to use.
+	VkeyName string `protobuf:"bytes,3,opt,name=vkey_name,json=vkeyName,proto3" json:"vkey_name,omitempty"`
+	// vkey_id is the ID of the verification key to use.
+	VkeyId uint64 `protobuf:"varint,4,opt,name=vkey_id,json=vkeyId,proto3" json:"vkey_id,omitempty"`
 }
 
 func (m *QueryVerifyRequest) Reset()         { *m = QueryVerifyRequest{} }
@@ -208,10 +213,15 @@ func (m *ProofVerifyResponse) GetVerified() bool {
 	return false
 }
 
+// VKey represents a verification key for ZK proof verification.
 type VKey struct {
-	KeyBytes    []byte `protobuf:"bytes,1,opt,name=key_bytes,json=keyBytes,proto3" json:"key_bytes,omitempty"`
-	Name        string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// key_bytes is the raw bytes of the verification key.
+	KeyBytes []byte `protobuf:"bytes,1,opt,name=key_bytes,json=keyBytes,proto3" json:"key_bytes,omitempty"`
+	// name is the unique human-readable identifier for this key.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// description provides additional context about the verification key.
 	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	// circuit_hash is the hash of the circuit this key is associated with.
 	CircuitHash string `protobuf:"bytes,4,opt,name=circuit_hash,json=circuitHash,proto3" json:"circuit_hash,omitempty"`
 	// authority is the uploader of the verification key.
 	Authority string `protobuf:"bytes,5,opt,name=authority,proto3" json:"authority,omitempty"`
@@ -377,7 +387,8 @@ func (m *QueryVKeyResponse) GetVkey() VKey {
 	return VKey{}
 }
 
-// QueryVKeyByNameRequest is the request type for the Query/VKeyByName RPC method
+// QueryVKeyByNameRequest is the request type for the Query/VKeyByName RPC
+// method
 type QueryVKeyByNameRequest struct {
 	// name is the unique name of the verification key
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -423,7 +434,8 @@ func (m *QueryVKeyByNameRequest) GetName() string {
 	return ""
 }
 
-// QueryVKeyByNameResponse is the response type for the Query/VKeyByName RPC method
+// QueryVKeyByNameResponse is the response type for the Query/VKeyByName RPC
+// method
 type QueryVKeyByNameResponse struct {
 	// vkey is the verification key
 	Vkey VKey `protobuf:"bytes,1,opt,name=vkey,proto3" json:"vkey"`
@@ -735,7 +747,8 @@ func (m *QueryHasVKeyResponse) GetId() uint64 {
 	return 0
 }
 
-// QueryNextVKeyIDRequest is the request type for the Query/NextVKeyID RPC method
+// QueryNextVKeyIDRequest is the request type for the Query/NextVKeyID RPC
+// method
 type QueryNextVKeyIDRequest struct {
 }
 
@@ -772,8 +785,10 @@ func (m *QueryNextVKeyIDRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryNextVKeyIDRequest proto.InternalMessageInfo
 
-// QueryNextVKeyIDResponse is the response type for the Query/NextVKeyID RPC method
+// QueryNextVKeyIDResponse is the response type for the Query/NextVKeyID RPC
+// method
 type QueryNextVKeyIDResponse struct {
+	// next_id is the next available verification key ID.
 	NextId uint64 `protobuf:"varint,1,opt,name=next_id,json=nextId,proto3" json:"next_id,omitempty"`
 }
 
@@ -1008,6 +1023,7 @@ type QueryClient interface {
 	VKeys(ctx context.Context, in *QueryVKeysRequest, opts ...grpc.CallOption) (*QueryVKeysResponse, error)
 	// HasVKey checks if a verification key exists by name
 	HasVKey(ctx context.Context, in *QueryHasVKeyRequest, opts ...grpc.CallOption) (*QueryHasVKeyResponse, error)
+	// NextVKeyID queries the next available verification key ID
 	NextVKeyID(ctx context.Context, in *QueryNextVKeyIDRequest, opts ...grpc.CallOption) (*QueryNextVKeyIDResponse, error)
 	// Params returns zk module parameters.
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
@@ -1096,6 +1112,7 @@ type QueryServer interface {
 	VKeys(context.Context, *QueryVKeysRequest) (*QueryVKeysResponse, error)
 	// HasVKey checks if a verification key exists by name
 	HasVKey(context.Context, *QueryHasVKeyRequest) (*QueryHasVKeyResponse, error)
+	// NextVKeyID queries the next available verification key ID
 	NextVKeyID(context.Context, *QueryNextVKeyIDRequest) (*QueryNextVKeyIDResponse, error)
 	// Params returns zk module parameters.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)


### PR DESCRIPTION
This pull request introduces a new CI workflow to check protobuf file generation, enhances proto/codec registration for the DKIM module, and improves documentation and maintainability for ZK and DKIM proto files and services. The changes ensure proto files are always up to date in CI, clarify service and message documentation, and modernize codec usage.

**CI/CD and Protobuf Generation Improvements:**
- Added a reusable GitHub Actions workflow (`proto-check.yaml`) that verifies protobuf files are up to date by running a new `make proto-gen-ci` target, which fails if there are uncommitted changes after proto generation. This is integrated into the main build pipeline. [[1]](diffhunk://#diff-e357c34f2beb2073374eb2c6f86e6add379bc2b047544180d421cb55688035ddR1-R29) [[2]](diffhunk://#diff-bd4e577d8cce18da4cecc900fca127f9a0d57d706c9cdb3507b778c1d574a54fR21-R25) [[3]](diffhunk://#diff-6740f4415a436e0909bfa691b319552cb273adb7cb69eaf2bb24f925c2dcdd69R86-R125) [[4]](diffhunk://#diff-6740f4415a436e0909bfa691b319552cb273adb7cb69eaf2bb24f925c2dcdd69R138-R147)

**DKIM Module Codec Modernization:**
- Updated `x/dkim/types/codec.go` to use the modern `legacy.RegisterAminoMsg` function for registering Amino messages and ensured the crypto codec is registered, improving compatibility and maintainability.

**ZK Module Protobuf and Service Enhancements:**
- Added and documented the `NextVKeyID` RPC method to the ZK module's proto and gRPC service, allowing clients to query the next available verification key ID. [[1]](diffhunk://#diff-aee20cda8e7618102eaf9c08afbf2e4a6177b2b8044d037cccf6411961896ec8R36-R37) [[2]](diffhunk://#diff-ef64bf288004be5d9b24e69e35da9e62a83eae218561b73c9c10bf554b3b9cc1R47) [[3]](diffhunk://#diff-ef64bf288004be5d9b24e69e35da9e62a83eae218561b73c9c10bf554b3b9cc1R147)
- Improved documentation for ZK proto messages, including `QueryVerifyRequest`, `VKey`, and related request/response types, making field purposes clearer. [[1]](diffhunk://#diff-aee20cda8e7618102eaf9c08afbf2e4a6177b2b8044d037cccf6411961896ec8R58-R66) [[2]](diffhunk://#diff-aee20cda8e7618102eaf9c08afbf2e4a6177b2b8044d037cccf6411961896ec8R75-L77) [[3]](diffhunk://#diff-aee20cda8e7618102eaf9c08afbf2e4a6177b2b8044d037cccf6411961896ec8L90-R109) [[4]](diffhunk://#diff-aee20cda8e7618102eaf9c08afbf2e4a6177b2b8044d037cccf6411961896ec8L144-R164) [[5]](diffhunk://#diff-d31177be936170b70610b30de78d85a3645feb901ffeefe6df50a1279f08c423R8222-R8234) [[6]](diffhunk://#diff-d31177be936170b70610b30de78d85a3645feb901ffeefe6df50a1279f08c423R8323-R8335) [[7]](diffhunk://#diff-d31177be936170b70610b30de78d85a3645feb901ffeefe6df50a1279f08c423L8460-R8471) [[8]](diffhunk://#diff-d31177be936170b70610b30de78d85a3645feb901ffeefe6df50a1279f08c423L8497-R8509) [[9]](diffhunk://#diff-d31177be936170b70610b30de78d85a3645feb901ffeefe6df50a1279f08c423L8755-R8768) [[10]](diffhunk://#diff-d31177be936170b70610b30de78d85a3645feb901ffeefe6df50a1279f08c423L8782-R8802)

**DKIM Module Protobuf Documentation:**
- Improved line wrapping and documentation for DKIM proto messages to enhance readability and maintain consistency. [[1]](diffhunk://#diff-0f3410f2439a931fde0601d8ce50a82acdd618789dae712ae72df3f12feaccddL30-R31) [[2]](diffhunk://#diff-709c7524e74dd3abb5e27120acd265b953104abca8d707aeb435def3b921706aL1242-R1243) [[3]](diffhunk://#diff-60d02454e7b2842c93b0c7bcf00288dbd995fc37e10189d06bacc6c35ba7e462L72-R73) [[4]](diffhunk://#diff-74c26fef3b388f3f319d764cba5cd2dd34ba615cdf4d143ef0c0d8bb426cad21L4349-R4350)

**Other Maintenance:**
- Minor go.mod clean-up for dependency specification.
- Removed unused test make target for clarity.
- Minor whitespace and formatting fixes in proto files.

These changes improve the reliability of protobuf generation in CI, clarify proto service contracts, and modernize the DKIM module's codec handling.