### PR TITLE
DO-219: harden release type detection in trigger-types and ungate downstream triggers

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -26,5 +26,8 @@ jobs:
     secrets: inherit
   trigger-homebrew:
     name: Trigger Homebrew
+    # No guard needed here — the homebrew-xion repo handles pre-release detection internally.
+    # For RC tags: only versioned formulas (xiond@26.rb, xiond@26.0.0-rc1.rb) are created.
+    # The main formula (xiond.rb / `brew install xiond`) only updates for stable releases.
     uses: ./.github/workflows/trigger-homebrew.yaml
     secrets: inherit

--- a/.github/workflows/trigger-types.yaml
+++ b/.github/workflows/trigger-types.yaml
@@ -1,27 +1,53 @@
 name: Trigger Types
 
 on:
-  workflow_call: # is called from the create-release workflow
+  workflow_call: # is called from the publish-release workflow
   workflow_dispatch: # manual trigger
 
 jobs:
   trigger-types:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine release type
+        id: release-type
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+
+          # Detect pre-release from tag name as primary signal.
+          # This is more reliable than the GitHub pre-release checkbox,
+          # which can be forgotten when creating a release.
+          # Only -rc is an accepted pre-release suffix (e.g. v26.0.0-rc1).
+          # Any other suffix (alpha, beta, etc.) is rejected.
+          if echo "$TAG_NAME" | grep -qE '\-rc[0-9]*$'; then
+            echo "release_type=prerelease" >> $GITHUB_OUTPUT
+            echo "Detected pre-release from tag name: $TAG_NAME"
+          elif echo "$TAG_NAME" | grep -qE '\-[a-zA-Z]'; then
+            echo "::error::Unsupported pre-release suffix in tag: $TAG_NAME. Only -rc is allowed (e.g. v26.0.0-rc1)."
+            exit 1
+          elif [ "${{ github.event.release.prerelease }}" == "true" ]; then
+            # Tag has no pre-release suffix but checkbox was checked — reject.
+            # If it's a pre-release, the tag must contain -rc.
+            echo "::error::GitHub pre-release checkbox is checked but tag $TAG_NAME has no -rc suffix. Either uncheck pre-release or fix the tag."
+            exit 1
+          else
+            # Stable release (e.g. v25.1.0)
+            echo "release_type=published" >> $GITHUB_OUTPUT
+            echo "Detected stable release: $TAG_NAME"
+          fi
+
       - name: Trigger xion-types workflow
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: burnt-labs/xion-types
           event-type: xion-types-release-trigger # NOTICE: must match the trigger in xion-types workflow
-          # -client-payload logic description-
-          # Checks if it's a pre-release: github.event.release.prerelease == true - if the release is marked as a pre-release, it sets release_type to 'prerelease'
-          # If not a pre-release, checks for latest release: github.event.release.prerelease == false && github.event.release.draft == false && github.event.release.make_latest == 'true' - ensures it's not a pre-release, not a draft, and is marked as the latest release
-          # Sets latest tag: If all the above conditions are true, it sets release_type to 'latest'
-          # Fallback to published: If none of the above conditions are met, it sets release_type to 'published'
+          # release_type values:
+          #   - 'prerelease': tag ends with -rc (e.g. v26.0.0-rc1)
+          #   - 'published': stable release (e.g. v25.1.0)
+          # Any other pre-release suffix (alpha, beta, etc.) will fail the workflow.
           client-payload: |
             {
-              "release_type": "${{ github.event.release.prerelease == true && 'prerelease' || (github.event.release.prerelease == false && github.event.release.draft == false && github.event.release.make_latest == 'true' && 'latest' || 'published') }}",
+              "release_type": "${{ steps.release-type.outputs.release_type }}",
               "tag_name": "${{ github.event.release.tag_name }}",
               "release_name": "${{ github.event.release.name }}"
             }


### PR DESCRIPTION
## Summary
- Refactored `trigger-types.yaml` to derive `release_type` from the tag name (`-rc` suffix) instead of relying on the GitHub pre-release checkbox, which can be forgotten during release creation.
- Added strict validation: only `-rc` pre-release suffixes are accepted; other suffixes (`-alpha`, `-beta`, etc.) and checkbox/tag mismatches fail the workflow.
- Removed `if` guards from `trigger-assets` and `trigger-homebrew` in `publish-release.yaml` — both downstream repos (`xion-assets`, `homebrew-xion`) already handle pre-release detection internally.
- Added `prereleased` to the `release:` trigger types so RC releases reach downstream workflows.

## Context
RC releases (e.g. `v26.0.0-rc1`) were not triggering `xion-types` generation because:
1. `publish-release.yaml` only listened for `released`, not `prereleased`.
2. `trigger-types.yaml` relied entirely on `github.event.release.prerelease`, which depends on the release author checking a box — a manual step that was sometimes skipped, causing RC packages to be published as `latest`.
