### PR TITLE
Correct DefaultParams TimeOffset to 30 seconds in nanoseconds

### DIFF
--- a/contrib/local/02-contracts.sh
+++ b/contrib/local/02-contracts.sh
@@ -44,8 +44,8 @@ sleep 6
 wasmd q tx $(echo "$RESP"| jq -r '.txhash') -o json | jq
 
 
-predictedAdress=$(wasmd q wasm build-address "$CODE_HASH" $(wasmd keys show validator -a --keyring-backend=test) $(echo -n "testing" | xxd -ps) "$INIT")
-wasmd q wasm contract "$predictedAdress" -o json | jq
+predictedAddress=$(wasmd q wasm build-address "$CODE_HASH" $(wasmd keys show validator -a --keyring-backend=test) $(echo -n "testing" | xxd -ps) "$INIT")
+wasmd q wasm contract "$predictedAddress" -o json | jq
 
 echo "### Query all"
 RESP=$(wasmd query wasm contract-state all "$CONTRACT" -o json)

--- a/x/jwk/keeper/migrations_test.go
+++ b/x/jwk/keeper/migrations_test.go
@@ -24,7 +24,7 @@ func TestMigrations(t *testing.T) {
 	params := k.GetParams(ctx)
 	require.NotNil(t, params)
 	require.Equal(t, uint64(10_000), params.DeploymentGas)
-	require.Equal(t, uint64(30_000), params.TimeOffset)
+	require.Equal(t, uint64(30_000_000_000), params.TimeOffset)
 
 	// Test NewMigrator
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)

--- a/x/jwk/migrations/v1/migration_test.go
+++ b/x/jwk/migrations/v1/migration_test.go
@@ -41,7 +41,7 @@ func TestMigrateStore(t *testing.T) {
 	var params types.Params
 	paramStore.GetParamSet(ctx.Ctx, &params)
 	require.Equal(t, uint64(10_000), params.DeploymentGas)
-	require.Equal(t, uint64(30_000), params.TimeOffset)
+	require.Equal(t, uint64(30_000_000_000), params.TimeOffset)
 
 	// Test case 2: Create a fresh param subspace with key table already set
 	storeKey2 := storetypes.NewKVStoreKey(types.StoreKey + "2")
@@ -64,5 +64,5 @@ func TestMigrateStore(t *testing.T) {
 	var params2 types.Params
 	paramStoreWithKeyTable.GetParamSet(ctx2.Ctx, &params2)
 	require.Equal(t, uint64(10_000), params2.DeploymentGas)
-	require.Equal(t, uint64(30_000), params2.TimeOffset)
+	require.Equal(t, uint64(30_000_000_000), params2.TimeOffset)
 }

--- a/x/jwk/types/params.go
+++ b/x/jwk/types/params.go
@@ -32,7 +32,7 @@ func NewParams(timeOffset, deploymentGas uint64) Params {
 // DefaultParams returns a default set of parameters
 func DefaultParams() Params {
 	deploymentGas := uint64(10_000)
-	timeOffset := uint64(30 * 1000) // default to 30 seconds
+	timeOffset := uint64(30_000_000_000) // 30 seconds in nanoseconds
 
 	return NewParams(timeOffset, deploymentGas)
 }

--- a/x/jwk/types/params_test.go
+++ b/x/jwk/types/params_test.go
@@ -216,7 +216,7 @@ func TestNewParams(t *testing.T) {
 func TestDefaultParams(t *testing.T) {
 	params := types.DefaultParams()
 	require.Equal(t, uint64(10_000), params.DeploymentGas)
-	require.Equal(t, uint64(30_000), params.TimeOffset)
+	require.Equal(t, uint64(30_000_000_000), params.TimeOffset)
 
 	// Default params should be valid
 	require.NoError(t, params.Validate())

--- a/x/jwk/types/types_test.go
+++ b/x/jwk/types/types_test.go
@@ -48,7 +48,7 @@ func TestJWKParams(t *testing.T) {
 	defaultParams := types.DefaultParams()
 	require.NotNil(t, defaultParams)
 	require.Equal(t, uint64(10_000), defaultParams.DeploymentGas)
-	require.Equal(t, uint64(30_000), defaultParams.TimeOffset)
+	require.Equal(t, uint64(30_000_000_000), defaultParams.TimeOffset)
 
 	// Test ParamSetPairs
 	pairs := defaultParams.ParamSetPairs()


### PR DESCRIPTION
This pull request updates the default value of the `TimeOffset` parameter throughout the codebase from 30,000 (milliseconds) to 30,000,000,000 (nanoseconds). This change ensures that time values are handled with nanosecond precision, aligning with expected time representations. The update is reflected in the parameter definition, as well as in all related tests and migration logic.

Parameter precision update:

* Changed the default `TimeOffset` in `DefaultParams` from 30,000 to 30,000,000,000 (nanoseconds), updating the comment to clarify the unit. (`x/jwk/types/params.go`)

Test consistency:

* Updated all test assertions to expect `TimeOffset` as 30,000,000,000 instead of 30,000, ensuring tests match the new default value. (`x/jwk/types/params_test.go`, `x/jwk/types/types_test.go`, `x/jwk/keeper/migrations_test.go`, `x/jwk/migrations/v1/migration_test.go`) [[1]](diffhunk://#diff-cb0b809ac4d8e2ee6df82c9cd7a2159e5d173d851abccbe914e610f160261f84L219-R219) [[2]](diffhunk://#diff-64fe9b0ec5e0940dc92128d5c035680d1774ef5a0540390532b510f864e575abL51-R51) [[3]](diffhunk://#diff-f084a59b36872240de7925b9bda565c5cea4de07539a534fd96d1b3c896c007fL27-R27) [[4]](diffhunk://#diff-15846506ea9459a8005bc9309b99eabf73583308edeab86279bb711596ffc2e8L44-R44) [[5]](diffhunk://#diff-15846506ea9459a8005bc9309b99eabf73583308edeab86279bb711596ffc2e8L67-R67)