### PR TITLE
fix: Normalize devops team reference in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,6 @@
 
 * @burnt-labs/burnt-engineering/burnt-protocol
 
-.github/ @burnt-labs/burnt-devops
-.goreleaser @burnt-labs/burnt-devops
-Dockerfile @burnt-labs/burnt-devops
+.github/ @burnt-labs/burnt-engineering/burnt-devops
+.goreleaser @burnt-labs/burnt-engineering/burnt-devops
+Dockerfile @burnt-labs/burnt-engineering/burnt-devops


### PR DESCRIPTION
Standardize @burnt-labs/burnt-devops to @burnt-labs/burnt-engineering/burnt-devops to match the nested team structure used in other repos.