### PR TITLE
feat(jwk): cap RSA key size to 4096 bits in audience registration

### DIFF
--- a/x/jwk/keeper/query_validate_jwt.go
+++ b/x/jwk/keeper/query_validate_jwt.go
@@ -39,6 +39,12 @@ func (k Keeper) ValidateJWT(goCtx context.Context, req *types.QueryValidateJWTRe
 		return nil, err
 	}
 
+	// Validate key size to prevent DoS attacks from oversized keys
+	// that might have been stored before validation was implemented
+	if err := types.ValidateJWKKeySize(key); err != nil {
+		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("stored key validation failed: %s", err))
+	}
+
 	// basic sanity check
 	if len(req.SigBytes) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "empty jwt")

--- a/x/jwk/types/key_size_test.go
+++ b/x/jwk/types/key_size_test.go
@@ -1,9 +1,8 @@
 package types_test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/base64"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,13 +47,19 @@ func TestValidateJWKKeySize(t *testing.T) {
 	})
 }
 
-// generateOversizedRSAJWK creates a JWK JSON string with the given RSA key size
+// generateOversizedRSAJWK creates a JWK JSON string with a mock RSA key of the
+// given bit length. Instead of calling rsa.GenerateKey (which is slow for large
+// keys and flaky in CI), we construct an rsa.PublicKey with a synthetic N of the
+// desired bit length. The validation logic only inspects the modulus size, so a
+// cryptographically valid key is not required.
 func generateOversizedRSAJWK(t *testing.T, bits int) string {
 	t.Helper()
-	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
-	require.NoError(t, err)
 
-	n := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
+	// Build a mock modulus: set the top bit so BitLen() == bits.
+	mockN := new(big.Int).SetBit(new(big.Int), bits-1, 1) // 2^(bits-1)
+	mockN.SetBit(mockN, 0, 1)                              // make it odd
+
+	n := base64.RawURLEncoding.EncodeToString(mockN.Bytes())
 	e := base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}) // 65537
 
 	return `{"kty":"RSA","use":"sig","kid":"test-oversized","alg":"RS256","n":"` + n + `","e":"` + e + `"}`

--- a/x/jwk/types/key_size_test.go
+++ b/x/jwk/types/key_size_test.go
@@ -24,7 +24,7 @@ func TestValidateJWKKeySize(t *testing.T) {
 	})
 
 	t.Run("oversized RSA key rejected in CreateAudience", func(t *testing.T) {
-		oversizedKey := generateOversizedRSAJWK(t, 8192)
+		oversizedKey := generateOversizedRSAJWK(t, types.MaxRSAKeyBits*2)
 		msg := types.NewMsgCreateAudience(admin, "https://test.example.com", oversizedKey)
 		err := msg.ValidateBasic()
 		require.Error(t, err)
@@ -32,16 +32,23 @@ func TestValidateJWKKeySize(t *testing.T) {
 	})
 
 	t.Run("oversized RSA key rejected in UpdateAudience", func(t *testing.T) {
-		oversizedKey := generateOversizedRSAJWK(t, 8192)
+		oversizedKey := generateOversizedRSAJWK(t, types.MaxRSAKeyBits*2)
 		msg := types.NewMsgUpdateAudience(admin, admin, "https://test.example.com", "", oversizedKey)
 		err := msg.ValidateBasic()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "exceeds maximum allowed")
 	})
 
-	t.Run("4096-bit RSA key accepted", func(t *testing.T) {
-		key4096 := generateOversizedRSAJWK(t, 4096)
-		msg := types.NewMsgCreateAudience(admin, "https://test.example.com", key4096)
+	t.Run("boundary RSA key accepted in CreateAudience", func(t *testing.T) {
+		key := generateOversizedRSAJWK(t, types.MaxRSAKeyBits)
+		msg := types.NewMsgCreateAudience(admin, "https://test.example.com", key)
+		err := msg.ValidateBasic()
+		require.NoError(t, err)
+	})
+
+	t.Run("boundary RSA key accepted in UpdateAudience", func(t *testing.T) {
+		key := generateOversizedRSAJWK(t, types.MaxRSAKeyBits)
+		msg := types.NewMsgUpdateAudience(admin, admin, "https://test.example.com", "", key)
 		err := msg.ValidateBasic()
 		require.NoError(t, err)
 	})

--- a/x/jwk/types/key_size_test.go
+++ b/x/jwk/types/key_size_test.go
@@ -1,0 +1,61 @@
+package types_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/burnt-labs/xion/x/jwk/types"
+)
+
+func TestValidateJWKKeySize(t *testing.T) {
+	admin := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+	validKey := `{"kty":"RSA","use":"sig","kid":"test","alg":"RS256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}`
+
+	t.Run("valid 2048-bit RSA key", func(t *testing.T) {
+		msg := types.NewMsgCreateAudience(admin, "https://test.example.com", validKey)
+		err := msg.ValidateBasic()
+		require.NoError(t, err)
+	})
+
+	t.Run("oversized RSA key rejected in CreateAudience", func(t *testing.T) {
+		oversizedKey := generateOversizedRSAJWK(t, 8192)
+		msg := types.NewMsgCreateAudience(admin, "https://test.example.com", oversizedKey)
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum allowed")
+	})
+
+	t.Run("oversized RSA key rejected in UpdateAudience", func(t *testing.T) {
+		oversizedKey := generateOversizedRSAJWK(t, 8192)
+		msg := types.NewMsgUpdateAudience(admin, admin, "https://test.example.com", "", oversizedKey)
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum allowed")
+	})
+
+	t.Run("4096-bit RSA key accepted", func(t *testing.T) {
+		key4096 := generateOversizedRSAJWK(t, 4096)
+		msg := types.NewMsgCreateAudience(admin, "https://test.example.com", key4096)
+		err := msg.ValidateBasic()
+		require.NoError(t, err)
+	})
+}
+
+// generateOversizedRSAJWK creates a JWK JSON string with the given RSA key size
+func generateOversizedRSAJWK(t *testing.T, bits int) string {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+	require.NoError(t, err)
+
+	n := base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}) // 65537
+
+	return `{"kty":"RSA","use":"sig","kid":"test-oversized","alg":"RS256","n":"` + n + `","e":"` + e + `"}`
+}

--- a/x/jwk/types/messages_audience.go
+++ b/x/jwk/types/messages_audience.go
@@ -1,6 +1,9 @@
 package types
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"fmt"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -16,6 +19,42 @@ const (
 	MaxJWKKeySize = 8192 // 8 KB
 	MaxAudSize    = 512
 
+	// MaxRSAKeyBits is the maximum allowed RSA key size in bits.
+	// 4096 bits is considered secure for the foreseeable future and prevents
+	// abuse via oversized keys that cause expensive verification operations.
+	MaxRSAKeyBits = 4096
+)
+
+// validateJWKKeySize checks that the raw key material does not exceed
+// the allowed maximum sizes. This prevents denial-of-service attacks
+// via oversized keys that are cheap to generate but expensive to verify against.
+func validateJWKKeySize(key jwk.Key) error {
+	var rawKey interface{}
+	if err := key.Raw(&rawKey); err != nil {
+		return errorsmod.Wrapf(ErrInvalidJWK, "unable to extract raw key: %s", err)
+	}
+
+	switch k := rawKey.(type) {
+	case *rsa.PublicKey:
+		if k.N.BitLen() > MaxRSAKeyBits {
+			return errorsmod.Wrapf(ErrInvalidJWK, "RSA key size %d bits exceeds maximum allowed %d bits", k.N.BitLen(), MaxRSAKeyBits)
+		}
+	case *rsa.PrivateKey:
+		if k.N.BitLen() > MaxRSAKeyBits {
+			return errorsmod.Wrapf(ErrInvalidJWK, "RSA key size %d bits exceeds maximum allowed %d bits", k.N.BitLen(), MaxRSAKeyBits)
+		}
+	case *ecdsa.PublicKey, *ecdsa.PrivateKey:
+		// ECDSA keys are inherently bounded by curve selection (P-256, P-384, P-521)
+	case ed25519.PublicKey, ed25519.PrivateKey:
+		// Ed25519 keys are fixed size (256 bits)
+	default:
+		// Unknown key type — allow but don't skip validation on known types
+	}
+
+	return nil
+}
+
+const (
 	TypeMsgCreateAudience = "create_audience"
 	TypeMsgUpdateAudience = "update_audience"
 	TypeMsgDeleteAudience = "delete_audience"
@@ -106,6 +145,10 @@ func (msg *MsgCreateAudience) ValidateBasic() error {
 		return errorsmod.Wrapf(ErrInvalidJWK, "invalid jwk format (%s)", err)
 	}
 
+	if err := validateJWKKeySize(key); err != nil {
+		return err
+	}
+
 	var sigAlg jwa.SignatureAlgorithm
 	if err := sigAlg.Accept(key.Algorithm().String()); err != nil {
 		return err
@@ -186,6 +229,10 @@ func (msg *MsgUpdateAudience) ValidateBasic() error {
 	key, err := jwk.ParseKey([]byte(msg.Key))
 	if err != nil {
 		return errorsmod.Wrapf(ErrInvalidJWK, "invalid jwk format (%s)", err)
+	}
+
+	if err := validateJWKKeySize(key); err != nil {
+		return err
 	}
 
 	var sigAlg jwa.SignatureAlgorithm

--- a/x/jwk/types/messages_audience.go
+++ b/x/jwk/types/messages_audience.go
@@ -28,6 +28,9 @@ const (
 // validateJWKKeySize checks that the raw key material does not exceed
 // the allowed maximum sizes. This prevents denial-of-service attacks
 // via oversized keys that are cheap to generate but expensive to verify against.
+//
+// NOTE: This validation is enforced at message ingress (ValidateBasic) only.
+// It does not retroactively reject keys already stored in state, by design.
 func validateJWKKeySize(key jwk.Key) error {
 	var rawKey interface{}
 	if err := key.Raw(&rawKey); err != nil {

--- a/x/jwk/types/messages_audience.go
+++ b/x/jwk/types/messages_audience.go
@@ -25,13 +25,13 @@ const (
 	MaxRSAKeyBits = 4096
 )
 
-// validateJWKKeySize checks that the raw key material does not exceed
+// ValidateJWKKeySize checks that the raw key material does not exceed
 // the allowed maximum sizes. This prevents denial-of-service attacks
 // via oversized keys that are cheap to generate but expensive to verify against.
 //
-// NOTE: This validation is enforced at message ingress (ValidateBasic) only.
-// It does not retroactively reject keys already stored in state, by design.
-func validateJWKKeySize(key jwk.Key) error {
+// This function is exported and reusable to allow key size validation
+// in multiple contexts including JWT verification and genesis validation.
+func ValidateJWKKeySize(key jwk.Key) error {
 	var rawKey interface{}
 	if err := key.Raw(&rawKey); err != nil {
 		return errorsmod.Wrapf(ErrInvalidJWK, "unable to extract raw key: %s", err)
@@ -148,7 +148,7 @@ func (msg *MsgCreateAudience) ValidateBasic() error {
 		return errorsmod.Wrapf(ErrInvalidJWK, "invalid jwk format (%s)", err)
 	}
 
-	if err := validateJWKKeySize(key); err != nil {
+	if err := ValidateJWKKeySize(key); err != nil {
 		return err
 	}
 
@@ -234,7 +234,7 @@ func (msg *MsgUpdateAudience) ValidateBasic() error {
 		return errorsmod.Wrapf(ErrInvalidJWK, "invalid jwk format (%s)", err)
 	}
 
-	if err := validateJWKKeySize(key); err != nil {
+	if err := ValidateJWKKeySize(key); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Enforce a maximum RSA key size of 4096 bits when creating or updating JWK audiences. This prevents potential abuse via oversized RSA keys that are cheap to generate but expensive to verify against.

## Changes

- Add `validateJWKKeySize()` helper in `x/jwk/types/messages_audience.go`
- Apply key size check in `ValidateBasic()` for both `MsgCreateAudience` and `MsgUpdateAudience`
- RSA keys > 4096 bits are rejected at message validation layer
- ECDSA/Ed25519 keys are inherently bounded and pass through
- Add comprehensive tests in `x/jwk/types/key_size_test.go`

## Linear

- ENG-1478

## Testing

- Unit tests for valid 2048-bit, valid 4096-bit, and rejected 8192-bit RSA keys
- Tests cover both CreateAudience and UpdateAudience paths