### PR TITLE
ENG-1488: Harden x/zk input validation and type safety

### DIFF
--- a/x/dkim/types/poseidon.go
+++ b/x/dkim/types/poseidon.go
@@ -158,7 +158,11 @@ func ComputePoseidonHash(pub string) (*big.Int, error) {
 		if key, err := x509.ParsePKIXPublicKey(block.Bytes); err != nil {
 			return nil, errors.Wrap(ErrParsingPubKey, "failed to decode public key")
 		} else {
-			publicKey = key.(*rsa.PublicKey)
+			rsaKey, ok := key.(*rsa.PublicKey)
+			if !ok {
+				return nil, errors.Wrap(ErrParsingPubKey, "key is not an RSA public key")
+			}
+			publicKey = rsaKey
 		}
 	} else {
 		publicKey = key

--- a/x/zk/types/msgs.go
+++ b/x/zk/types/msgs.go
@@ -13,12 +13,17 @@ var (
 	_ sdk.Msg = &MsgUpdateParams{}
 )
 
-// types/msgs.go
-
 // ProofSystemGroth16 and ProofSystemUltraHonk are typed aliases for the ProofSystem enum.
 const (
 	ProofSystemGroth16   = ProofSystem_PROOF_SYSTEM_GROTH16
 	ProofSystemUltraHonk = ProofSystem_PROOF_SYSTEM_ULTRA_HONK_ZK
+)
+
+const (
+	// MaxVKeyNameLen is the maximum allowed length (in bytes) for a verification key name.
+	MaxVKeyNameLen = 128
+	// MaxVKeyDescLen is the maximum allowed length (in bytes) for a verification key description.
+	MaxVKeyDescLen = 1024
 )
 
 func (m *MsgAddVKey) ValidateBasic() error {
@@ -28,6 +33,14 @@ func (m *MsgAddVKey) ValidateBasic() error {
 
 	if m.Name == "" {
 		return fmt.Errorf("name cannot be empty")
+	}
+
+	if len(m.Name) > MaxVKeyNameLen {
+		return fmt.Errorf("name length %d bytes exceeds maximum %d bytes", len(m.Name), MaxVKeyNameLen)
+	}
+
+	if len(m.Description) > MaxVKeyDescLen {
+		return fmt.Errorf("description length %d bytes exceeds maximum %d bytes", len(m.Description), MaxVKeyDescLen)
 	}
 
 	if len(m.VkeyBytes) == 0 {
@@ -55,6 +68,14 @@ func (m *MsgUpdateVKey) ValidateBasic() error {
 
 	if m.Name == "" {
 		return fmt.Errorf("name cannot be empty")
+	}
+
+	if len(m.Name) > MaxVKeyNameLen {
+		return fmt.Errorf("name length %d bytes exceeds maximum %d bytes", len(m.Name), MaxVKeyNameLen)
+	}
+
+	if len(m.Description) > MaxVKeyDescLen {
+		return fmt.Errorf("description length %d bytes exceeds maximum %d bytes", len(m.Description), MaxVKeyDescLen)
 	}
 
 	if len(m.VkeyBytes) == 0 {

--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -126,5 +126,10 @@ func (p Params) GasCostForSize(size uint64) (uint64, error) {
 	}
 
 	chunks := (size + p.UploadChunkSize - 1) / p.UploadChunkSize
-	return chunks * p.UploadChunkGas, nil
+	cost := chunks * p.UploadChunkGas
+	// Check for overflow
+	if chunks != 0 && cost/chunks != p.UploadChunkGas {
+		return 0, errorsmod.Wrapf(ErrInvalidParams, "gas cost overflow: chunks=%d, chunkGas=%d", chunks, p.UploadChunkGas)
+	}
+	return cost, nil
 }


### PR DESCRIPTION
Defensive hardening for x/zk module.

Fixes:
- Add VKey format validation in MsgUpdateVKey (consistency with MsgAddVKey)
- Checked type assertion in ComputePoseidonHash
- Length limits on VKey name (128) and description (1024)
- Overflow check in GasCostForSize multiplication

All changes are non-breaking defensive hardening.