### PR TITLE
ENG-1489: Harden x/jwk amino registration, input validation, and state hygiene

### DIFF
--- a/x/jwk/genesis_test.go
+++ b/x/jwk/genesis_test.go
@@ -187,6 +187,7 @@ func TestGenesisRoundTrip(t *testing.T) {
 
 func TestGenesisValidation(t *testing.T) {
 	validAdmin := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+	validKey := `{"kty":"RSA","use":"sig","kid":"test","alg":"RS256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}`
 
 	tests := []struct {
 		name      string
@@ -201,7 +202,7 @@ func TestGenesisValidation(t *testing.T) {
 					{
 						Admin: validAdmin,
 						Aud:   "audience1",
-						Key:   "key1",
+						Key:   validKey,
 					},
 				},
 			},
@@ -215,7 +216,21 @@ func TestGenesisValidation(t *testing.T) {
 					{
 						Admin: "invalid-address",
 						Aud:   "audience1",
-						Key:   "key1",
+						Key:   validKey,
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid JWK key in genesis",
+			genesis: types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Admin: validAdmin,
+						Aud:   "audience1",
+						Key:   "not-valid-json",
 					},
 				},
 			},
@@ -229,12 +244,12 @@ func TestGenesisValidation(t *testing.T) {
 					{
 						Admin: validAdmin,
 						Aud:   "audience1",
-						Key:   "key1",
+						Key:   validKey,
 					},
 					{
 						Admin: validAdmin,
 						Aud:   "audience1", // Duplicate
-						Key:   "key2",
+						Key:   validKey,
 					},
 				},
 			},

--- a/x/jwk/types/codec.go
+++ b/x/jwk/types/codec.go
@@ -11,6 +11,8 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgCreateAudience{}, "jwk/CreateAudience", nil)
 	cdc.RegisterConcrete(&MsgUpdateAudience{}, "jwk/UpdateAudience", nil)
 	cdc.RegisterConcrete(&MsgDeleteAudience{}, "jwk/DeleteAudience", nil)
+	cdc.RegisterConcrete(&MsgCreateAudienceClaim{}, "jwk/CreateAudienceClaim", nil)
+	cdc.RegisterConcrete(&MsgDeleteAudienceClaim{}, "jwk/DeleteAudienceClaim", nil)
 	// this line is used by starport scaffolding # 2
 }
 
@@ -19,6 +21,8 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgCreateAudience{},
 		&MsgUpdateAudience{},
 		&MsgDeleteAudience{},
+		&MsgCreateAudienceClaim{},
+		&MsgDeleteAudienceClaim{},
 	)
 	// this line is used by starport scaffolding # 3
 

--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	errorsmod "cosmossdk.io/errors"
@@ -43,8 +44,26 @@ func (gs GenesisState) Validate() error {
 
 		// Validate JWK key format if key is present
 		if elem.Key != "" {
-			if _, err := jwk.ParseKey([]byte(elem.Key)); err != nil {
+			// Enforce size limit before parsing to avoid expensive operations on huge inputs.
+			if len(elem.Key) > MaxJWKKeySize {
+				return errorsmod.Wrapf(ErrInvalidJWK, "key size %d exceeds maximum %d bytes for audience %s", len(elem.Key), MaxJWKKeySize, elem.Aud)
+			}
+
+			parsedKey, err := jwk.ParseKey([]byte(elem.Key))
+			if err != nil {
 				return errorsmod.Wrapf(ErrInvalidJWK, "invalid JWK in genesis for audience %s: %s", elem.Aud, err)
+			}
+
+			// Reject symmetric (HMAC) and "none" signature algorithms — these are
+			// disallowed for the same reasons as in MsgCreateAudience/MsgUpdateAudience.
+			var sigAlg jwa.SignatureAlgorithm
+			if err := sigAlg.Accept(parsedKey.Algorithm().String()); err != nil {
+				return errorsmod.Wrapf(ErrInvalidJWK, "invalid algorithm in genesis JWK for audience %s: %s", elem.Aud, err)
+			}
+
+			switch sigAlg {
+			case jwa.HS256, jwa.HS384, jwa.HS512, jwa.NoSignature:
+				return errorsmod.Wrapf(ErrInvalidJWK, "invalid algorithm %s in genesis JWK for audience %s", sigAlg.String(), elem.Aud)
 			}
 		}
 	}

--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -3,10 +3,12 @@ package types
 import (
 	"fmt"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
+
 	errorsmod "cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
 // DefaultIndex is the default global index
@@ -50,4 +52,3 @@ func (gs GenesisState) Validate() error {
 
 	return gs.Params.Validate()
 }
-

--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 

--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -6,7 +6,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
@@ -40,9 +39,11 @@ func (gs GenesisState) Validate() error {
 		}
 		audienceIndexMap[index] = struct{}{}
 
-		// Validate JWK key format
-		if _, err := jwk.ParseKey([]byte(elem.Key)); err != nil {
-			return errorsmod.Wrapf(ErrInvalidJWK, "invalid JWK in genesis for audience %s: %s", elem.Aud, err)
+		// Validate JWK key format if key is present
+		if elem.Key != "" {
+			if _, err := jwk.ParseKey([]byte(elem.Key)); err != nil {
+				return errorsmod.Wrapf(ErrInvalidJWK, "invalid JWK in genesis for audience %s: %s", elem.Aud, err)
+			}
 		}
 	}
 	// this line is used by starport scaffolding # genesis/types/validate

--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
 // DefaultIndex is the default global index
@@ -38,6 +39,11 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("duplicated index for audience")
 		}
 		audienceIndexMap[index] = struct{}{}
+
+		// Validate JWK key format
+		if _, err := jwk.ParseKey([]byte(elem.Key)); err != nil {
+			return errorsmod.Wrapf(ErrInvalidJWK, "invalid JWK in genesis for audience %s: %s", elem.Aud, err)
+		}
 	}
 	// this line is used by starport scaffolding # genesis/types/validate
 

--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -49,3 +49,4 @@ func (gs GenesisState) Validate() error {
 
 	return gs.Params.Validate()
 }
+

--- a/x/jwk/types/genesis_test.go
+++ b/x/jwk/types/genesis_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,7 +12,12 @@ import (
 	"github.com/burnt-labs/xion/x/jwk/types"
 )
 
+// validRSAKey is a well-formed RSA JWK with RS256 used across genesis tests.
+const validRSAKey = `{"kty":"RSA","use":"sig","kid":"test","alg":"RS256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}`
+
 func TestGenesisState_Validate(t *testing.T) {
+	adminAddr := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
 	tests := []struct {
 		desc     string
 		genState *types.GenesisState
@@ -29,14 +35,28 @@ func TestGenesisState_Validate(t *testing.T) {
 				AudienceList: []types.Audience{
 					{
 						Aud:   "0",
-						Admin: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+						Admin: adminAddr,
 					},
 					{
 						Aud:   "1",
-						Admin: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+						Admin: adminAddr,
 					},
 				},
 				// this line is used by starport scaffolding # types/genesis/validField
+			},
+			valid: true,
+		},
+		{
+			desc: "valid genesis state with JWK key",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "test-audience",
+						Admin: adminAddr,
+						Key:   validRSAKey,
+					},
+				},
 			},
 			valid: true,
 		},
@@ -46,11 +66,11 @@ func TestGenesisState_Validate(t *testing.T) {
 				AudienceList: []types.Audience{
 					{
 						Aud:   "0",
-						Admin: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+						Admin: adminAddr,
 					},
 					{
 						Aud:   "0",
-						Admin: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+						Admin: adminAddr,
 					},
 				},
 			},
@@ -63,6 +83,76 @@ func TestGenesisState_Validate(t *testing.T) {
 					{
 						Aud:   "test-audience",
 						Admin: "invalid-address",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "key exceeding MaxJWKKeySize is rejected before parsing",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "big-key-audience",
+						Admin: adminAddr,
+						Key:   strings.Repeat("a", types.MaxJWKKeySize+1),
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "HMAC HS256 key is rejected",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "hmac-audience",
+						Admin: adminAddr,
+						Key:   `{"kty":"oct","alg":"HS256","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}`,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "HMAC HS384 key is rejected",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "hmac384-audience",
+						Admin: adminAddr,
+						Key:   `{"kty":"oct","alg":"HS384","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}`,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "HMAC HS512 key is rejected",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "hmac512-audience",
+						Admin: adminAddr,
+						Key:   `{"kty":"oct","alg":"HS512","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}`,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "invalid JWK format is rejected",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "bad-key-audience",
+						Admin: adminAddr,
+						Key:   `{"not":"a valid jwk"}`,
 					},
 				},
 			},

--- a/x/jwk/types/messages_audience.go
+++ b/x/jwk/types/messages_audience.go
@@ -13,6 +13,9 @@ import (
 )
 
 const (
+	MaxJWKKeySize = 8192 // 8 KB
+	MaxAudSize    = 512
+
 	TypeMsgCreateAudience = "create_audience"
 	TypeMsgUpdateAudience = "update_audience"
 	TypeMsgDeleteAudience = "delete_audience"
@@ -60,6 +63,13 @@ func (msg *MsgCreateAudience) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Admin)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid admin address (%s)", err)
+	}
+
+	if len(msg.Key) > MaxJWKKeySize {
+		return errorsmod.Wrapf(ErrInvalidJWK, "key size %d exceeds maximum %d bytes", len(msg.Key), MaxJWKKeySize)
+	}
+	if len(msg.Aud) > MaxAudSize {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "aud length %d exceeds maximum %d", len(msg.Aud), MaxAudSize)
 	}
 
 	key, err := jwk.ParseKey([]byte(msg.Key))
@@ -128,6 +138,13 @@ func (msg *MsgUpdateAudience) ValidateBasic() error {
 	_, err = sdk.AccAddressFromBech32(msg.Admin)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid admin address (%s)", err)
+	}
+
+	if len(msg.Key) > MaxJWKKeySize {
+		return errorsmod.Wrapf(ErrInvalidJWK, "key size %d exceeds maximum %d bytes", len(msg.Key), MaxJWKKeySize)
+	}
+	if len(msg.Aud) > MaxAudSize {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "aud length %d exceeds maximum %d", len(msg.Aud), MaxAudSize)
 	}
 
 	key, err := jwk.ParseKey([]byte(msg.Key))
@@ -272,6 +289,10 @@ func (msg *MsgDeleteAudienceClaim) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Admin)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid admin address (%s)", err)
+	}
+
+	if len(msg.AudHash) != 32 {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "hash must be 32 byte sha256")
 	}
 
 	return nil

--- a/x/jwk/types/messages_audience.go
+++ b/x/jwk/types/messages_audience.go
@@ -295,7 +295,11 @@ func (msg *MsgDeleteAudienceClaim) ValidateBasic() error {
 	}
 
 	if len(msg.AudHash) != 32 {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "hash must be 32 byte sha256")
+		return errorsmod.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"audience hash must be 32-byte SHA-256 (got %d bytes)",
+			len(msg.AudHash),
+		)
 	}
 
 	return nil

--- a/x/jwk/types/messages_audience.go
+++ b/x/jwk/types/messages_audience.go
@@ -146,6 +146,9 @@ func (msg *MsgUpdateAudience) ValidateBasic() error {
 	if len(msg.Aud) > MaxAudSize {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "aud length %d exceeds maximum %d", len(msg.Aud), MaxAudSize)
 	}
+	if len(msg.NewAud) > MaxAudSize {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "new_aud length %d exceeds maximum %d", len(msg.NewAud), MaxAudSize)
+	}
 
 	key, err := jwk.ParseKey([]byte(msg.Key))
 	if err != nil {

--- a/x/jwk/types/messages_test.go
+++ b/x/jwk/types/messages_test.go
@@ -204,7 +204,8 @@ func TestMsgCreateAudienceClaim(t *testing.T) {
 func TestMsgDeleteAudienceClaim(t *testing.T) {
 	adminAddr := authtypes.NewModuleAddress(govtypes.ModuleName)
 	admin := adminAddr.String()
-	hash := []byte("test-hash")
+	hash := make([]byte, 32) // valid 32-byte SHA256 hash
+	copy(hash, []byte("test-hash"))
 
 	msg := types.NewMsgDeleteAudienceClaim(adminAddr, hash)
 
@@ -478,4 +479,71 @@ func TestMsgCreateAudienceClaimValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMsgCreateAudienceSizeLimits(t *testing.T) {
+	admin := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+	validKey := `{"kty":"RSA","use":"sig","kid":"test","alg":"RS256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}`
+
+	t.Run("key exceeding 8KB limit", func(t *testing.T) {
+		oversizedKey := make([]byte, types.MaxJWKKeySize+1)
+		for i := range oversizedKey {
+			oversizedKey[i] = 'a'
+		}
+		msg := types.NewMsgCreateAudience(admin, "test-aud", string(oversizedKey))
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
+	})
+
+	t.Run("aud exceeding 512 byte limit", func(t *testing.T) {
+		oversizedAud := make([]byte, types.MaxAudSize+1)
+		for i := range oversizedAud {
+			oversizedAud[i] = 'a'
+		}
+		msg := types.NewMsgCreateAudience(admin, string(oversizedAud), validKey)
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
+	})
+
+	t.Run("key at exact 8KB limit is accepted for parsing", func(t *testing.T) {
+		// A key of exactly MaxJWKKeySize passes the size check but will fail JWK parsing
+		maxKey := make([]byte, types.MaxJWKKeySize)
+		for i := range maxKey {
+			maxKey[i] = 'a'
+		}
+		msg := types.NewMsgCreateAudience(admin, "test-aud", string(maxKey))
+		err := msg.ValidateBasic()
+		// Should fail on JWK parse, not size limit
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid jwk")
+	})
+
+	t.Run("aud at exact 512 byte limit", func(t *testing.T) {
+		exactAud := make([]byte, types.MaxAudSize)
+		for i := range exactAud {
+			exactAud[i] = 'a'
+		}
+		msg := types.NewMsgCreateAudience(admin, string(exactAud), validKey)
+		err := msg.ValidateBasic()
+		// Should pass size check (valid aud + valid key)
+		require.NoError(t, err)
+	})
+}
+
+func TestMsgUpdateAudienceNewAudSizeLimit(t *testing.T) {
+	admin := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+	validKey := `{"kty":"RSA","use":"sig","kid":"test","alg":"RS256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}`
+
+	t.Run("new_aud exceeding 512 byte limit", func(t *testing.T) {
+		oversizedAud := make([]byte, types.MaxAudSize+1)
+		for i := range oversizedAud {
+			oversizedAud[i] = 'a'
+		}
+		msg := types.NewMsgUpdateAudience(admin, admin, "test-aud", string(oversizedAud), validKey)
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new_aud length")
+	})
 }


### PR DESCRIPTION
Defensive hardening for x/jwk module.

Fixes:
- **F-25:** Register MsgCreateAudienceClaim and MsgDeleteAudienceClaim in Amino codec and InterfaceRegistry
- **F-33:** Add size limits on JWK Key (8KB) and Aud (512 bytes) fields in ValidateBasic
- **F-51:** Add AudHash length validation in MsgDeleteAudienceClaim (consistency with Create)
- **F-44:** Validate JWK key format in genesis state validation

All changes are non-breaking defensive hardening.