### PR TITLE
fix type workflows

### DIFF
--- a/.github/workflows/release-downstream.yaml
+++ b/.github/workflows/release-downstream.yaml
@@ -11,7 +11,7 @@ jobs:
   trigger-types:
     name: Trigger Types
     if: github.repository == 'burnt-labs/xion'
-    uses: burnt-labs/xion-types/.github/workflows/release.yaml@main
+    uses: ./.github/workflows/trigger-types.yaml
     with:
       release_tag: ${{ github.event.release.tag_name }}
     secrets: inherit

--- a/.github/workflows/trigger-types.yaml
+++ b/.github/workflows/trigger-types.yaml
@@ -2,11 +2,16 @@ name: Trigger Types
 
 on:
   workflow_call:
+    inputs:
+      release_tag:
+        description: "Release tag (e.g. v28.0.0)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag (e.g. v28.0.0). Defaults to the release event tag."
-        required: false
+        description: "Release tag (e.g. v28.0.0)"
+        required: true
         type: string
 
 jobs:
@@ -14,5 +19,5 @@ jobs:
     name: Release Types
     uses: burnt-labs/xion-types/.github/workflows/release.yaml@main
     with:
-      release_tag: ${{ inputs.release_tag || github.event.release.tag_name }}
+      release_tag: ${{ inputs.release_tag }}
     secrets: inherit


### PR DESCRIPTION
This pull request updates the workflow configuration for triggering downstream releases, focusing on improving how release tags are passed and simplifying the workflow structure. The main changes are grouped below:

Workflow structure changes:

* The `trigger-types` job in `.github/workflows/release-downstream.yaml` now uses a local workflow file (`trigger-types.yaml`) instead of referencing the remote workflow in `xion-types`.

Release tag input handling:

* The `trigger-types.yaml` workflow now requires the `release_tag` input for both `workflow_call` and `workflow_dispatch` triggers, removing the previous default/fallback behavior.
* The `release-types` job in `trigger-types.yaml` now passes the `release_tag` input directly, instead of using a fallback to `github.event.release.tag_name`.