### PR TITLE
x/zk: proof/input size limits with governance floor validation

### DIFF
--- a/x/zk/keeper/query_server_test.go
+++ b/x/zk/keeper/query_server_test.go
@@ -712,6 +712,10 @@ func TestQueryProofVerify(t *testing.T) {
 		vkeyID       uint64
 		shouldError  bool
 		errorMsg     string
+		// expectedErr, when non-nil, is checked with require.ErrorIs in addition to the
+		// errorMsg substring check. Storing this in the struct avoids fragile name-based
+		// switches in the test runner.
+		expectedErr error
 	}{
 		{
 			name:         "verify proof success with valid data using vkey name",

--- a/x/zk/keeper/query_server_test.go
+++ b/x/zk/keeper/query_server_test.go
@@ -754,6 +754,7 @@ func TestQueryProofVerify(t *testing.T) {
 			vkeyName:     "email_auth_circuit",
 			shouldError:  true,
 			errorMsg:     "proof size",
+			expectedErr:  types.ErrProofTooLarge,
 		},
 		{
 			name:         "public inputs exceed max size",
@@ -762,6 +763,7 @@ func TestQueryProofVerify(t *testing.T) {
 			vkeyName:     "email_auth_circuit",
 			shouldError:  true,
 			errorMsg:     "public inputs size",
+			expectedErr:  types.ErrPublicInputsTooLarge,
 		},
 		{
 			name:         "non-existent vkey name",
@@ -839,11 +841,8 @@ func TestQueryProofVerify(t *testing.T) {
 
 			if tc.shouldError {
 				require.Error(t, err, "Expected error for test case: %s", tc.name)
-				switch tc.name {
-				case "proof exceeds max size":
-					require.ErrorIs(t, err, types.ErrProofTooLarge)
-				case "public inputs exceed max size":
-					require.ErrorIs(t, err, types.ErrPublicInputsTooLarge)
+				if tc.expectedErr != nil {
+					require.ErrorIs(t, err, tc.expectedErr)
 				}
 				if tc.errorMsg != "" {
 					require.Contains(t, err.Error(), tc.errorMsg, "Error message mismatch for test case: %s", tc.name)


### PR DESCRIPTION
## Summary

- Adds four new `Params` fields (`MaxGroth16ProofSizeBytes`, `MaxGroth16PublicInputSizeBytes`, `MaxUltraHonkProofSizeBytes`, `MaxUltraHonkPublicInputSizeBytes`) that bound proof and public-input payload sizes in `ProofVerify` and `ProofVerifyUltraHonk`.
- Introduces `MinProofOrInputSizeBytes` (1 KiB) floor constant. `Validate()` now rejects any size-limit param below this floor with `ErrInvalidParams`, preventing governance from accidentally setting limits so low that all ZK verification fails.
- Documents the rationale for default values with inline comments (Groth16 proof ~200 bytes → 4 KiB default; public inputs 30 KiB; UltraHonk proof 20 KiB; UltraHonk public inputs 10 KiB).
- Clarifies `WithMaxLimitDefaults()` upgrade-compatibility semantics in both the helper and `MsgUpdateParams.ValidateBasic()` comments.
- Refactors `TestQueryProofVerify`: replaces name-based switch for error-type assertions with an `expectedErr` field on the test-case struct.
- Adds migration v3 to seed existing chains with the new param defaults.

## Test plan

- [ ] `go test ./x/zk/...` passes
- [ ] `go test ./x/zk/types/...` — `TestParamsValidate` covers zero-value, positive, and below-floor cases
- [ ] `TestQueryProofVerify` uses struct-level `expectedErr` field; no name-based switch
- [ ] `TestQueryProofVerify_ParamMaxSizeEnforced` validates tightened limits reject real payloads
- [ ] Migration test confirms existing zero-value chains get defaults applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)