### PR TITLE
fix: use flat team slugs in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 # # Assign a role as a Code Owner:
 # /config/ @@maintainer
 
-* @burnt-labs/burnt-engineering/burnt-protocol
+* @burnt-labs/burnt-protocol
 
 .github/ @burnt-labs/burnt-devops
 .goreleaser @burnt-labs/burnt-devops


### PR DESCRIPTION
Use @burnt-labs/burnt-devops and @burnt-labs/burnt-protocol directly — nested team references are ignored by GitHub and cause unexpected ownership assignment.