### PR TITLE
Add gas metering for ZK and DKIM proof verification queries

### DIFF
--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -205,6 +205,12 @@ func (k Querier) Authenticate(c context.Context, req *types.QueryAuthenticateReq
 	}
 	indices := params.PublicInputIndices
 
+	// Charge gas proportional to public inputs count to prevent free DoS
+	// via Stargate-whitelisted or CosmWasm-callable query endpoints.
+	sdkCtx := sdk.UnwrapSDKContext(c)
+	authGas := types.AuthenticateBaseGas + types.AuthenticatePerPublicInputGas*uint64(len(req.PublicInputs))
+	sdkCtx.GasMeter().ConsumeGas(authGas, "dkim/Authenticate: proof verification cost")
+
 	if uint64(len(req.PublicInputs)) < indices.MinLength {
 		return nil, errors.Wrapf(types.ErrNotEnoughPublicInputs, "insufficient public inputs, need at least %d elements, got %d", indices.MinLength, len(req.PublicInputs))
 	}

--- a/x/dkim/types/params.go
+++ b/x/dkim/types/params.go
@@ -9,6 +9,15 @@ import (
 const (
 	DefaultMaxPubKeySizeBytes uint64 = 512
 
+	// Gas constants for the Authenticate query.
+	// These are charged to prevent free DoS via Stargate-whitelisted or
+	// CosmWasm-callable query endpoints that run Groth16 BN254 verification.
+
+	// AuthenticateBaseGas is the flat overhead charged on every Authenticate call.
+	AuthenticateBaseGas uint64 = 100_000
+	// AuthenticatePerPublicInputGas is charged per public input element.
+	AuthenticatePerPublicInputGas uint64 = 500
+
 	// Default public input indices for the Authenticate query
 	DefaultMinPublicInputsLength  uint64 = 88
 	DefaultEmailHashIndex         uint64 = 68

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/burnt-labs/xion/x/zk/types"
@@ -70,6 +71,12 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 			params.MaxGroth16PublicInputSizeBytes,
 		)
 	}
+
+	// Charge gas proportional to proof + public inputs sizes to prevent free DoS
+	// via Stargate-whitelisted or CosmWasm-callable query endpoints.
+	sdkCtx := sdk.UnwrapSDKContext(c)
+	verifyGas := types.ProofVerifyBaseGas + types.ProofVerifyPerByteGas*(uint64(len(req.Proof))+publicInputsSize)
+	sdkCtx.GasMeter().ConsumeGas(verifyGas, "zk/ProofVerify: proof verification cost")
 
 	snarkProof, err := parser.UnmarshalCircomProofJSON(req.Proof)
 	if err != nil {
@@ -133,6 +140,12 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 			params.MaxUltraHonkPublicInputSizeBytes,
 		)
 	}
+
+	// Charge gas proportional to proof + public inputs sizes to prevent free DoS
+	// via Stargate-whitelisted or CosmWasm-callable query endpoints.
+	sdkCtxHonk := sdk.UnwrapSDKContext(c)
+	honkGas := types.ProofVerifyUltraHonkBaseGas + types.ProofVerifyUltraHonkPerByteGas*(uint64(len(req.GetProof()))+uint64(len(req.GetPublicInputs())))
+	sdkCtxHonk.GasMeter().ConsumeGas(honkGas, "zk/ProofVerifyUltraHonk: proof verification cost")
 
 	// Resolve vkey by name or ID (prefer name when both are set, same as Groth16 verify-proof)
 	var vkey types.VKey

--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -28,6 +28,21 @@ const (
 	// DefaultMaxUltraHonkPublicInputSizeBytes caps the maximum allowed UltraHonk public inputs bytes size.
 	// For UltraHonk, public inputs are provided as raw bytes.
 	DefaultMaxUltraHonkPublicInputSizeBytes uint64 = 10 * 1024 // 10 KiB
+
+	// Gas constants for proof verification queries.
+	// These are charged proportional to input sizes to prevent free DoS via
+	// Stargate-whitelisted or CosmWasm-callable query endpoints.
+
+	// ProofVerifyBaseGas is the flat overhead charged on every Groth16/BN254 proof
+	// verification call regardless of payload size.
+	ProofVerifyBaseGas uint64 = 100_000
+	// ProofVerifyPerByteGas is charged per byte of proof + public inputs for Groth16.
+	ProofVerifyPerByteGas uint64 = 10
+
+	// ProofVerifyUltraHonkBaseGas is the flat overhead for every UltraHonk verification call.
+	ProofVerifyUltraHonkBaseGas uint64 = 150_000
+	// ProofVerifyUltraHonkPerByteGas is charged per byte of proof + public inputs for UltraHonk.
+	ProofVerifyUltraHonkPerByteGas uint64 = 15
 )
 
 // NewParams creates a new Params instance.


### PR DESCRIPTION
## Summary

- `x/zk/keeper/query_server.go`: `ProofVerify` (Groth16/BN254) and `ProofVerifyUltraHonk` now consume gas proportional to proof + public input sizes before running the cryptographic verification.
- `x/dkim/keeper/query_server.go`: `Authenticate` now consumes gas proportional to the number of public inputs before running Groth16 verification.
- Gas constants added to `x/zk/types/params.go` and `x/dkim/types/params.go`.

Both endpoints are Stargate-whitelisted and CosmWasm-callable.  Without gas accounting, a contract can loop these endpoints and saturate validator CPU at zero cost.  Gas is charged as a flat base cost plus a per-byte (or per-element) rate, applied after the size-limit checks and immediately before the expensive cryptographic work begins.

## Test plan

- [ ] Existing unit tests pass
- [ ] Manual: submit a `ProofVerify` query and confirm gas usage is non-zero in the response
- [ ] Manual: submit an `Authenticate` query and confirm gas usage is non-zero in the response
- [ ] Confirm that simulate mode still works (simulate skips the fee check but still tracks gas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)