### PR TITLE
Transfer AudienceClaim when UpdateAudience changes admin

### DIFF
--- a/x/jwk/keeper/msg_server_audience.go
+++ b/x/jwk/keeper/msg_server_audience.go
@@ -148,6 +148,22 @@ func (k msgServer) UpdateAudience(goCtx context.Context, msg *types.MsgUpdateAud
 		audience.Aud = msg.NewAud
 	}
 
+	// If the admin is changing, transfer the audience claim to the new admin.
+	// Without this, the old admin retains the claim and could re-create the
+	// audience, while the new admin cannot manage the audience claim.
+	if msg.NewAdmin != msg.Admin {
+		newAdminAddr, err := sdk.AccAddressFromBech32(msg.NewAdmin)
+		if err != nil {
+			return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid new admin address (%s)", err)
+		}
+		// Compute the hash for the audience that is being transferred.
+		effectiveAud := audience.Aud
+		audHash := sha256.Sum256([]byte(effectiveAud))
+		// Remove old admin's claim and install the new admin's claim.
+		k.RemoveAudienceClaim(ctx, audHash[:])
+		k.SetAudienceClaim(ctx, audHash[:], newAdminAddr)
+	}
+
 	k.SetAudience(ctx, audience)
 
 	return &types.MsgUpdateAudienceResponse{Audience: &audience}, nil


### PR DESCRIPTION
## Summary

- `x/jwk/keeper/msg_server_audience.go`: `UpdateAudience` now transfers the `AudienceClaim` KV entry to the new admin when `msg.NewAdmin != msg.Admin`.

## Background

`UpdateAudience` wrote the new admin address into the `Audience` record but left the `AudienceClaim` pointing at the old admin.  This created two problems:

1. The new admin held no audience claim, so they could not call `CreateAudienceClaim` to re-assert ownership or `DeleteAudienceClaim` to remove it.
2. The old admin still held the claim and could call `CreateAudience` again for the same `aud` value (after deleting the existing audience), effectively reclaiming a resource they had transferred away.

## Fix

After updating the `Audience` record, if the admin is changing, remove the old admin's `AudienceClaim` for the audience's SHA-256 hash and write a new `AudienceClaim` for the new admin.

## Test plan

- [ ] Existing `x/jwk` unit tests pass
- [ ] New scenario: create audience → update admin → verify old admin claim is gone → verify new admin claim exists
- [ ] New scenario: create audience → update admin → old admin attempts CreateAudienceClaim → should fail with "audience already claimed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)