### PR TITLE
fix(x/jwk): correct TimeOffset via Migrate2To3 (ConsensusVersion 3)

### DIFF
--- a/x/jwk/keeper/migrations.go
+++ b/x/jwk/keeper/migrations.go
@@ -5,6 +5,7 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	v1 "github.com/burnt-labs/xion/x/jwk/migrations/v1"
+	v3 "github.com/burnt-labs/xion/x/jwk/migrations/v3"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -20,4 +21,11 @@ func NewMigrator(jwkSubspace paramtypes.Subspace) Migrator {
 // Migrate1To2 migrates from version 1 to 2
 func (m Migrator) Migrate1To2(ctx sdk.Context) error {
 	return v1.MigrateStore(ctx, m.jwkSubspace)
+}
+
+// Migrate2To3 migrates from version 2 to 3.
+// It corrects the TimeOffset param that was set to 30_000 (30 microseconds)
+// by Migrate1To2 instead of the correct 30_000_000_000 (30 seconds in nanoseconds).
+func (m Migrator) Migrate2To3(ctx sdk.Context) error {
+	return v3.MigrateStore(ctx, m.jwkSubspace)
 }

--- a/x/jwk/migrations/v3/migrate.go
+++ b/x/jwk/migrations/v3/migrate.go
@@ -1,0 +1,27 @@
+package v3
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/burnt-labs/xion/x/jwk/types"
+)
+
+// MigrateStore corrects the TimeOffset param that was set to 30_000 (30
+// microseconds) by the v1→v2 migration instead of the correct value of
+// 30_000_000_000 (30 seconds in nanoseconds).
+func MigrateStore(ctx sdk.Context, jwkSubspace paramtypes.Subspace) error {
+	ctx.Logger().Info("Running x/jwk Migration v2 to v3: correcting TimeOffset")
+
+	if !jwkSubspace.HasKeyTable() {
+		jwkSubspace = jwkSubspace.WithKeyTable(types.ParamKeyTable())
+	}
+
+	correctTimeOffset := uint64(30_000_000_000) // 30 seconds in nanoseconds
+	ctx.Logger().Info(fmt.Sprintf("setting TimeOffset to %d", correctTimeOffset))
+	jwkSubspace.Set(ctx, types.ParamStoreKeyTimeOffset, correctTimeOffset)
+
+	return nil
+}

--- a/x/jwk/migrations/v3/migrate_test.go
+++ b/x/jwk/migrations/v3/migrate_test.go
@@ -1,0 +1,69 @@
+package v3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	v3migration "github.com/burnt-labs/xion/x/jwk/migrations/v3"
+	"github.com/burnt-labs/xion/x/jwk/types"
+)
+
+func TestMigrateStore(t *testing.T) {
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+	tkey := storetypes.NewTransientStoreKey(paramstypes.TStoreKey)
+	ctx := testutil.DefaultContextWithDB(t, storeKey, tkey)
+	cdc := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+
+	// Simulate the broken state: subspace with key table, TimeOffset set to the
+	// wrong value that Migrate1To2 wrote (30_000 instead of 30_000_000_000).
+	paramStore := paramstypes.NewSubspace(
+		cdc,
+		codec.NewLegacyAmino(),
+		storeKey,
+		tkey,
+		types.ModuleName,
+	).WithKeyTable(types.ParamKeyTable())
+
+	brokenTimeOffset := uint64(30_000)
+	paramStore.Set(ctx.Ctx, types.ParamStoreKeyTimeOffset, brokenTimeOffset)
+
+	var beforeParams types.Params
+	paramStore.GetParamSet(ctx.Ctx, &beforeParams)
+	require.Equal(t, brokenTimeOffset, beforeParams.TimeOffset, "pre-condition: TimeOffset should be the broken value")
+
+	// Run the migration.
+	err := v3migration.MigrateStore(ctx.Ctx, paramStore)
+	require.NoError(t, err)
+
+	// Verify TimeOffset was corrected.
+	var afterParams types.Params
+	paramStore.GetParamSet(ctx.Ctx, &afterParams)
+	require.Equal(t, uint64(30_000_000_000), afterParams.TimeOffset, "TimeOffset should be 30 seconds in nanoseconds after migration")
+}
+
+func TestMigrateStoreWithoutKeyTable(t *testing.T) {
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+	tkey := storetypes.NewTransientStoreKey(paramstypes.TStoreKey)
+	ctx := testutil.DefaultContextWithDB(t, storeKey, tkey)
+	cdc := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+
+	// Create subspace WITHOUT key table to exercise that branch.
+	paramStore := paramstypes.NewSubspace(
+		cdc,
+		codec.NewLegacyAmino(),
+		storeKey,
+		tkey,
+		types.ModuleName,
+	)
+
+	err := v3migration.MigrateStore(ctx.Ctx, paramStore)
+	require.NoError(t, err)
+}

--- a/x/jwk/module.go
+++ b/x/jwk/module.go
@@ -124,10 +124,13 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
-	// Register migration
+	// Register migrations
 	m := keeper.NewMigrator(am.jwkSubspace)
 	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1To2); err != nil {
-		panic(fmt.Sprintf("failed to migrate x/jwk v3: %v", err))
+		panic(fmt.Sprintf("failed to migrate x/jwk from v1 to v2: %v", err))
+	}
+	if err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2To3); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/jwk from v2 to v3: %v", err))
 	}
 }
 
@@ -149,4 +152,4 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion is a sequence number for state-breaking change of the module. It should be incremented on each consensus-breaking change introduced by the module. To avoid wrong/empty versions, the initial version should be set to 1
-func (AppModule) ConsensusVersion() uint64 { return 2 }
+func (AppModule) ConsensusVersion() uint64 { return 3 }


### PR DESCRIPTION
## Summary

- `Migrate1To2` in `x/jwk` ran at v27 with a broken default value: `TimeOffset = 30_000` (30 microseconds) instead of `30_000_000_000` (30 seconds in nanoseconds). Because `ConsensusVersion` was already at 2, the migration would not re-run at v29.
- This PR bumps `ConsensusVersion` from 2 → 3 and adds `Migrate2To3` that forces the correct value via `jwkSubspace.Set(ctx, types.ParamStoreKeyTimeOffset, uint64(30_000_000_000))`.
- A new `migrations/v3` package is introduced, mirroring the pattern of `migrations/v1`.

## Changes

- `x/jwk/migrations/v3/migrate.go` — new `MigrateStore` function that sets `TimeOffset = 30_000_000_000`
- `x/jwk/migrations/v3/migrate_test.go` — tests that verify the broken value is overwritten and that the no-key-table branch is exercised
- `x/jwk/keeper/migrations.go` — adds `Migrate2To3` backed by the new v3 package
- `x/jwk/module.go` — bumps `ConsensusVersion` to 3 and registers the `2 → 3` migration

## Test plan

- [ ] `go test ./x/jwk/migrations/v3/...` — new migration unit tests pass
- [ ] `go test ./x/jwk/keeper/...` — existing keeper tests (including migration tests) continue to pass
- [ ] `go test ./x/jwk/...` — full module test suite passes
- [ ] Verify on a v29 upgrade simulation that `TimeOffset` is corrected from `30_000` to `30_000_000_000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)