### PR TITLE
revert gas metering on Stargate-whitelisted queries

### DIFF
--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -217,13 +217,6 @@ func (k Querier) Authenticate(c context.Context, req *types.QueryAuthenticateReq
 		)
 	}
 
-	// Charge gas proportional to public inputs count and proof size to prevent free DoS
-	// via Stargate-whitelisted or CosmWasm-callable query endpoints.
-	sdkCtx := sdk.UnwrapSDKContext(c)
-	authGas := types.AuthenticateBaseGas +
-		types.AuthenticatePerPublicInputGas*uint64(len(req.PublicInputs)) +
-		types.AuthenticatePerProofByteGas*uint64(len(req.Proof))
-	sdkCtx.GasMeter().ConsumeGas(authGas, "dkim/Authenticate: proof verification cost")
 
 	if uint64(len(req.PublicInputs)) < indices.MinLength {
 		return nil, errors.Wrapf(types.ErrNotEnoughPublicInputs, "insufficient public inputs, need at least %d elements, got %d", indices.MinLength, len(req.PublicInputs))

--- a/x/dkim/types/msgs_test.go
+++ b/x/dkim/types/msgs_test.go
@@ -339,7 +339,7 @@ func TestValidateDkimPubKeys(t *testing.T) {
 	t.Run("1024-bit key accepted for genesis path", func(t *testing.T) {
 		// Genesis validation must accept legacy keys (e.g. Yahoo s1024).
 		// ValidateDkimPubKeys must NOT enforce the 2048-bit minimum.
-		smallKey, err := rsa.GenerateKey(rand.Reader, 1024)
+		smallKey, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 		require.NoError(t, err)
 		pkixBytes, err := x509.MarshalPKIXPublicKey(&smallKey.PublicKey)
 		require.NoError(t, err)
@@ -473,7 +473,7 @@ func TestValidateDkimPubKeysWithRevocation(t *testing.T) {
 
 	t.Run("1024-bit key rejected for message path", func(t *testing.T) {
 		// Message validation must enforce the 2048-bit minimum.
-		smallKey, err := rsa.GenerateKey(rand.Reader, 1024)
+		smallKey, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 		require.NoError(t, err)
 		pkixBytes, err := x509.MarshalPKIXPublicKey(&smallKey.PublicKey)
 		require.NoError(t, err)

--- a/x/dkim/types/params.go
+++ b/x/dkim/types/params.go
@@ -18,17 +18,6 @@ const (
 	// matches the x/zk Groth16 limit and prevents allocator DoS from multi-MB blobs.
 	MaxDKIMProofSizeBytes uint64 = 4 * 1024 // 4 KiB
 
-	// Gas constants for the Authenticate query.
-	// These are charged to prevent free DoS via Stargate-whitelisted or
-	// CosmWasm-callable query endpoints that run Groth16 BN254 verification.
-
-	// AuthenticateBaseGas is the flat overhead charged on every Authenticate call.
-	AuthenticateBaseGas uint64 = 100_000
-	// AuthenticatePerPublicInputGas is charged per public input element.
-	AuthenticatePerPublicInputGas uint64 = 500
-	// AuthenticatePerProofByteGas is charged per byte of proof JSON to account
-	// for the deserialization cost and to prevent free DoS from large proof blobs.
-	AuthenticatePerProofByteGas uint64 = 10
 
 	// Default public input indices for the Authenticate query
 	DefaultMinPublicInputsLength  uint64 = 88

--- a/x/dkim/types/pubkey_test.go
+++ b/x/dkim/types/pubkey_test.go
@@ -45,7 +45,7 @@ func TestCanonicalizeRSAPublicKeyEncodingInvariant(t *testing.T) {
 func TestParseRSAPublicKeyAcceptsSmallKeys(t *testing.T) {
 	// ParseRSAPublicKey should parse without enforcing minimum key size.
 	// This is needed for genesis/state-loading of legacy keys (e.g. Yahoo s1024).
-	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	key, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 	require.NoError(t, err)
 
 	pkixBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
@@ -71,7 +71,7 @@ func TestValidateRSAKeySize(t *testing.T) {
 	})
 
 	t.Run("rejects 1024-bit key", func(t *testing.T) {
-		key, err := rsa.GenerateKey(rand.Reader, 1024)
+		key, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 		require.NoError(t, err)
 		err = types.ValidateRSAKeySize(&key.PublicKey)
 		require.Error(t, err)

--- a/x/jwk/types/key_size_test.go
+++ b/x/jwk/types/key_size_test.go
@@ -64,7 +64,7 @@ func generateOversizedRSAJWK(t *testing.T, bits int) string {
 
 	// Build a mock modulus: set the top bit so BitLen() == bits.
 	mockN := new(big.Int).SetBit(new(big.Int), bits-1, 1) // 2^(bits-1)
-	mockN.SetBit(mockN, 0, 1)                              // make it odd
+	mockN.SetBit(mockN, 0, 1)                             // make it odd
 
 	n := base64.RawURLEncoding.EncodeToString(mockN.Bytes())
 	e := base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}) // 65537

--- a/x/xion/types/feegrant.go
+++ b/x/xion/types/feegrant.go
@@ -17,17 +17,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
-// gasCostPerIteration is charged per allowance / message check in the fee-grant
-// Accept loops below.  The value is intentionally small because these are
-// O(n) bookkeeping iterations, not cryptographic operations.
-//
-// Upstream tracking: https://github.com/cosmos/cosmos-sdk/issues/9054
-//
-//	https://github.com/cosmos/cosmos-sdk/discussions/9072
-//
-// For the heavier cryptographic query endpoints (ZK proof verification and
-// DKIM authentication), dedicated gas constants are defined in
-// x/zk/types/params.go and x/dkim/types/params.go respectively.
+// TODO: Revisit this once we have proper gas fee framework.
+// Tracking issues https://github.com/cosmos/cosmos-sdk/issues/9054, https://github.com/cosmos/cosmos-sdk/discussions/9072
 const (
 	gasCostPerIteration = uint64(10)
 )

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -11,7 +11,6 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/burnt-labs/xion/x/zk/types"
@@ -71,12 +70,6 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 			params.MaxGroth16PublicInputSizeBytes,
 		)
 	}
-
-	// Charge gas proportional to proof + public inputs sizes to prevent free DoS
-	// via Stargate-whitelisted or CosmWasm-callable query endpoints.
-	sdkCtx := sdk.UnwrapSDKContext(c)
-	verifyGas := types.ProofVerifyBaseGas + types.ProofVerifyPerByteGas*(uint64(len(req.Proof))+publicInputsSize)
-	sdkCtx.GasMeter().ConsumeGas(verifyGas, "zk/ProofVerify: proof verification cost")
 
 	snarkProof, err := parser.UnmarshalCircomProofJSON(req.Proof)
 	if err != nil {
@@ -140,12 +133,6 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 			params.MaxUltraHonkPublicInputSizeBytes,
 		)
 	}
-
-	// Charge gas proportional to proof + public inputs sizes to prevent free DoS
-	// via Stargate-whitelisted or CosmWasm-callable query endpoints.
-	sdkCtxHonk := sdk.UnwrapSDKContext(c)
-	honkGas := types.ProofVerifyUltraHonkBaseGas + types.ProofVerifyUltraHonkPerByteGas*(uint64(len(req.GetProof()))+uint64(len(req.GetPublicInputs())))
-	sdkCtxHonk.GasMeter().ConsumeGas(honkGas, "zk/ProofVerifyUltraHonk: proof verification cost")
 
 	// Resolve vkey by name or ID (prefer name when both are set, same as Groth16 verify-proof)
 	var vkey types.VKey

--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -28,21 +28,6 @@ const (
 	// DefaultMaxUltraHonkPublicInputSizeBytes caps the maximum allowed UltraHonk public inputs bytes size.
 	// For UltraHonk, public inputs are provided as raw bytes.
 	DefaultMaxUltraHonkPublicInputSizeBytes uint64 = 10 * 1024 // 10 KiB
-
-	// Gas constants for proof verification queries.
-	// These are charged proportional to input sizes to prevent free DoS via
-	// Stargate-whitelisted or CosmWasm-callable query endpoints.
-
-	// ProofVerifyBaseGas is the flat overhead charged on every Groth16/BN254 proof
-	// verification call regardless of payload size.
-	ProofVerifyBaseGas uint64 = 100_000
-	// ProofVerifyPerByteGas is charged per byte of proof + public inputs for Groth16.
-	ProofVerifyPerByteGas uint64 = 10
-
-	// ProofVerifyUltraHonkBaseGas is the flat overhead for every UltraHonk verification call.
-	ProofVerifyUltraHonkBaseGas uint64 = 150_000
-	// ProofVerifyUltraHonkPerByteGas is charged per byte of proof + public inputs for UltraHonk.
-	ProofVerifyUltraHonkPerByteGas uint64 = 15
 )
 
 // NewParams creates a new Params instance.


### PR DESCRIPTION
## Summary

- Removes `ConsumeGas` calls from `dkim/Authenticate`, `zk/ProofVerify`, and `zk/ProofVerifyUltraHonk` query endpoints added in PR #507
- These queries are Stargate-whitelisted (`wasmbindings/stargate_whitelist.go`) so CosmWasm contracts can call them without gas charges — adding gas metering breaks existing deployed contracts after the v29 upgrade
- Removes now-unused gas constants from `x/dkim/types/params.go` and `x/zk/types/params.go`
- Reverts expanded comment in `x/xion/types/feegrant.go` that referenced removed constants
- Suppresses gosec G403 in test files that intentionally generate 1024-bit RSA keys for legacy key handling tests

## Test plan

- [x] `golangci-lint run` passes (0 issues)
- [x] `golangci-lint run --tests=false` passes (0 issues)
- [x] All unit tests pass with coverage
- [ ] Verify Stargate-whitelisted queries work from CosmWasm contracts without gas charges

🤖 Generated with [Claude Code](https://claude.com/claude-code)