### PR TITLE
x/zk: require governance authority for AddVKey registration

### DIFF
--- a/x/zk/keeper/msg_server.go
+++ b/x/zk/keeper/msg_server.go
@@ -30,7 +30,14 @@ func (ms msgServer) AddVKey(goCtx context.Context, msg *types.MsgAddVKey) (*type
 		return nil, err
 	}
 
-	// Add the vkey (authority check and validation happens inside)
+	// Only the module authority (governance) may register verification keys.
+	// Allowing arbitrary callers to register VKeys permits squatting of canonical
+	// key namespaces that other contracts and modules depend on for ZK authentication.
+	if msg.Authority != ms.k.GetAuthority() {
+		return nil, errors.Wrapf(types.ErrInvalidAuthority, "expected %s, got %s", ms.k.GetAuthority(), msg.Authority)
+	}
+
+	// Add the vkey
 	id, err := ms.k.AddVKey(ctx, msg.Authority, msg.Name, msg.VkeyBytes, msg.Description)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Gate `MsgAddVKey` behind the module authority (governance), consistent with `UpdateParams` and other privileged operations in the zk module.
- Previously, any address could register a verification key name and become its permanent owner, since `UpdateVKey` and `RemoveVKey` enforce ownership against the stored authority value.
- VKey namespaces are relied upon by contracts and modules for ZK authentication routing; this change ensures only governance can register new keys.

## Test plan
- [ ] Verify `MsgAddVKey` from a non-authority address returns `ErrInvalidAuthority`
- [ ] Verify `MsgAddVKey` from the module authority succeeds
- [ ] Verify `UpdateVKey` and `RemoveVKey` behavior is unchanged