### PR TITLE
x/zk: add gas metering to ProofVerify query

### DIFF
--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/burnt-labs/xion/x/zk/types"
@@ -70,6 +71,12 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 			params.MaxGroth16PublicInputSizeBytes,
 		)
 	}
+
+	// Charge gas before executing the BN254 pairing check. Proof verification is
+	// computationally expensive and must be metered to prevent a single query from
+	// consuming unbounded node resources.
+	sdkCtx := sdk.UnwrapSDKContext(c)
+	sdkCtx.GasMeter().ConsumeGas(types.ProofVerifyGas, "zk/ProofVerify: bn254 pairing")
 
 	snarkProof, err := parser.UnmarshalCircomProofJSON(req.Proof)
 	if err != nil {

--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -28,6 +28,11 @@ const (
 	// DefaultMaxUltraHonkPublicInputSizeBytes caps the maximum allowed UltraHonk public inputs bytes size.
 	// For UltraHonk, public inputs are provided as raw bytes.
 	DefaultMaxUltraHonkPublicInputSizeBytes uint64 = 10 * 1024 // 10 KiB
+
+	// ProofVerifyGas is the flat gas cost charged per BN254 proof verification.
+	// BN254 pairing checks are computationally expensive; this cost bounds the
+	// number of verifications an account can submit per block under its gas limit.
+	ProofVerifyGas uint64 = 500_000
 )
 
 // NewParams creates a new Params instance.


### PR DESCRIPTION
## Summary
- Add a flat `ProofVerifyGas` charge (500,000 gas) to the `ProofVerify` gRPC query handler before proof deserialization and BN254 pairing verification.
- BN254 pairing checks are computationally expensive; this metering bounds the compute cost per query to the caller's gas budget.
- The gas constant is defined in `types/params.go` alongside the existing VKey upload gas parameters for consistency.

## Test plan
- [ ] Verify `ProofVerify` queries consume 500,000 gas
- [ ] Verify queries that exceed the caller's gas budget fail with out-of-gas
- [ ] Verify valid proof verification still succeeds when sufficient gas is available