### PR TITLE
fix(x/jwk): remove gas charge from Stargate-whitelisted ValidateJWT (ENG-BLOCK1)

### DIFF
--- a/x/jwk/keeper/query_validate_jwt.go
+++ b/x/jwk/keeper/query_validate_jwt.go
@@ -45,10 +45,13 @@ func (k Keeper) ValidateJWT(goCtx context.Context, req *types.QueryValidateJWTRe
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("stored key validation failed: %s", err))
 	}
 
-	// Charge gas proportional to key size to prevent free DoS via
-	// Stargate-whitelisted or CosmWasm-callable query endpoints.
-	verifyGas := types.JWTVerifyBaseGas + types.JWTVerifyPerByteGas*uint64(len(audience.Key))
-	ctx.GasMeter().ConsumeGas(verifyGas, "jwk/ValidateJWT: JWT verification cost")
+	// NOTE: No explicit gas charge here.
+	// ValidateJWT is Stargate-whitelisted and called by CosmWasm abstract-account
+	// contracts in their sudo handler. Charging 50 k+ gas per call would push
+	// those contracts over their existing gas budgets and break them post-upgrade.
+	// DoS protection is handled structurally: audience keys are bounded to
+	// MaxJWKKeySize bytes at registration time (ValidateJWKKeySize above), so
+	// the cryptographic work per call is already capped.
 
 	// basic sanity check
 	if len(req.SigBytes) == 0 {

--- a/x/jwk/types/types.go
+++ b/x/jwk/types/types.go
@@ -1,14 +1,10 @@
 package types
 
 const (
-	// Gas constants for JWT/JWS verification queries.
-	// These are charged to prevent free DoS via Stargate-whitelisted or
-	// CosmWasm-callable query endpoints.
-
-	// JWTVerifyBaseGas is the flat overhead charged on every ValidateJWT call.
-	JWTVerifyBaseGas uint64 = 50_000
-	// JWTVerifyPerByteGas is charged per byte of the stored key for ValidateJWT.
-	JWTVerifyPerByteGas uint64 = 10
+	// Gas constants for JWS verification queries.
+	// ValidateJWT (Stargate-whitelisted) does NOT charge explicit gas — see
+	// query_validate_jwt.go for the rationale. VerifyJWS is not whitelisted
+	// and charges gas to bound verification cost.
 
 	// JWSVerifyBaseGas is the flat overhead charged on every VerifyJWS call.
 	JWSVerifyBaseGas uint64 = 50_000


### PR DESCRIPTION
## Summary

- `ValidateJWT` is whitelisted in `wasmbindings/stargate_whitelist.go` and is called by deployed abstract-account CosmWasm contracts inside their `sudo` authentication handler.
- The `50_000 + 10×keyLen` gas charge added to `ValidateJWT` in the recent hardening work would be charged against those contracts' execution gas budgets — budgets sized before this gas cost existed — causing them to exceed their limits and fail on every authentication attempt post-upgrade.
- This PR removes the explicit `ConsumeGas` call from `ValidateJWT` and the now-unused `JWTVerifyBaseGas`/`JWTVerifyPerByteGas` constants.
- DoS protection is retained structurally: audience keys are already capped at `MaxJWKKeySize` bytes at registration time by `ValidateJWKKeySize`, which bounds the per-call cryptographic work without runtime gas metering.
- `VerifyJWS` (not Stargate-whitelisted, not called by contracts) retains its gas metering unchanged.

## Files changed

- `x/jwk/keeper/query_validate_jwt.go` — remove `ConsumeGas` call; add explanatory comment
- `x/jwk/types/types.go` — remove unused `JWTVerifyBaseGas`/`JWTVerifyPerByteGas` constants; update comment

## Test plan

- [ ] Verify `go build ./x/jwk/...` compiles cleanly (no unused-constant errors)
- [ ] Run existing unit tests: `go test ./x/jwk/...`
- [ ] Confirm `VerifyJWS` still charges gas (constants and call site untouched)
- [ ] Confirm `ValidateJWT` no longer appears in gas traces from wasm contract calls in devnet smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)