### PR TITLE
x/zk: add 1 MiB upper bound to proof/input size params in Validate()

### DIFF
--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -33,6 +33,16 @@ const (
 	// BN254 pairing checks are computationally expensive; this cost bounds the
 	// number of verifications an account can submit per block under its gas limit.
 	ProofVerifyGas uint64 = 500_000
+
+	// MinProofOrInputSizeBytes is the minimum value governance may set for any
+	// proof or public-input size parameter (must be at least 1 byte).
+	MinProofOrInputSizeBytes uint64 = 1
+
+	// MaxAllowedProofOrInputSizeBytes is the hard upper bound governance may set
+	// for any proof or public-input size parameter. Capping at 1 MiB prevents a
+	// governance proposal from setting these values to uint64_max, which would
+	// effectively disable the size limits and open a DoS vector.
+	MaxAllowedProofOrInputSizeBytes uint64 = 1_048_576 // 1 MiB
 )
 
 // NewParams creates a new Params instance.
@@ -97,20 +107,32 @@ func (p Params) Validate() error {
 		return errorsmod.Wrapf(ErrInvalidParams, "upload_chunk_gas must be positive")
 	}
 
-	if p.MaxGroth16ProofSizeBytes == 0 {
+	if p.MaxGroth16ProofSizeBytes < MinProofOrInputSizeBytes {
 		return errorsmod.Wrapf(ErrInvalidParams, "max_groth16_proof_size_bytes must be positive")
 	}
+	if p.MaxGroth16ProofSizeBytes > MaxAllowedProofOrInputSizeBytes {
+		return errorsmod.Wrapf(ErrInvalidParams, "max_groth16_proof_size_bytes exceeds hard upper bound of %d bytes", MaxAllowedProofOrInputSizeBytes)
+	}
 
-	if p.MaxGroth16PublicInputSizeBytes == 0 {
+	if p.MaxGroth16PublicInputSizeBytes < MinProofOrInputSizeBytes {
 		return errorsmod.Wrapf(ErrInvalidParams, "max_groth16_public_input_size_bytes must be positive")
 	}
-
-	if p.MaxUltraHonkProofSizeBytes == 0 {
-		return errorsmod.Wrapf(ErrInvalidParams, "max_ultra_honk_proof_size_bytes must be positive")
+	if p.MaxGroth16PublicInputSizeBytes > MaxAllowedProofOrInputSizeBytes {
+		return errorsmod.Wrapf(ErrInvalidParams, "max_groth16_public_input_size_bytes exceeds hard upper bound of %d bytes", MaxAllowedProofOrInputSizeBytes)
 	}
 
-	if p.MaxUltraHonkPublicInputSizeBytes == 0 {
+	if p.MaxUltraHonkProofSizeBytes < MinProofOrInputSizeBytes {
+		return errorsmod.Wrapf(ErrInvalidParams, "max_ultra_honk_proof_size_bytes must be positive")
+	}
+	if p.MaxUltraHonkProofSizeBytes > MaxAllowedProofOrInputSizeBytes {
+		return errorsmod.Wrapf(ErrInvalidParams, "max_ultra_honk_proof_size_bytes exceeds hard upper bound of %d bytes", MaxAllowedProofOrInputSizeBytes)
+	}
+
+	if p.MaxUltraHonkPublicInputSizeBytes < MinProofOrInputSizeBytes {
 		return errorsmod.Wrapf(ErrInvalidParams, "max_ultra_honk_public_input_size_bytes must be positive")
+	}
+	if p.MaxUltraHonkPublicInputSizeBytes > MaxAllowedProofOrInputSizeBytes {
+		return errorsmod.Wrapf(ErrInvalidParams, "max_ultra_honk_public_input_size_bytes exceeds hard upper bound of %d bytes", MaxAllowedProofOrInputSizeBytes)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Governance could set `MaxGroth16ProofSizeBytes`, `MaxGroth16PublicInputSizeBytes`, `MaxUltraHonkProofSizeBytes`, or `MaxUltraHonkPublicInputSizeBytes` to `uint64_max` (or any arbitrarily large value), effectively disabling the size limits and creating a DoS vector.
- Adds two new constants to `x/zk/types/params.go`:
  - `MinProofOrInputSizeBytes = 1` — formalises the existing floor check
  - `MaxAllowedProofOrInputSizeBytes = 1_048_576` — hard 1 MiB ceiling
- `Validate()` now rejects any of the four proof/public-input size params outside the range `[1, 1_048_576]`.
- All existing default values (4 KiB, 30 KiB, 20 KiB, 10 KiB) remain well within the new ceiling.

## Test plan

- [ ] Existing `TestParamsValidate` passes (default params are within bounds)
- [ ] Add test cases: params with any proof/input size > `MaxAllowedProofOrInputSizeBytes` should return an error from `Validate()`
- [ ] Confirm `make test` passes for `x/zk/types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)