### PR TITLE
fix: ProofVerifyUltraHonk ErrInternal handling and DecodeJWT key size validation

### DIFF
--- a/x/jwk/keeper/query_decode_jwt.go
+++ b/x/jwk/keeper/query_decode_jwt.go
@@ -38,6 +38,12 @@ func (k Keeper) DecodeJWT(goCtx context.Context, req *types.QueryDecodeJWTReques
 		return nil, err
 	}
 
+	// Validate key size to prevent DoS attacks from oversized keys
+	// that might have been stored before validation was implemented
+	if err := types.ValidateJWKKeySize(key); err != nil {
+		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("stored key validation failed: %s", err))
+	}
+
 	// basic sanity check
 	if len(req.SigBytes) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "empty jwt")

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -193,9 +193,11 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 
 	verified, err := verifier.VerifyWithBytes(proof, chunks)
 	if err != nil {
+		if goerrors.Is(err, barretenberg.ErrInternal) {
+			return nil, errors.Wrap(err, "internal verifier error")
+		}
 		if goerrors.Is(err, barretenberg.ErrVerificationFailed) ||
-			goerrors.Is(err, barretenberg.ErrInvalidPublicInputs) ||
-			goerrors.Is(err, barretenberg.ErrInternal) {
+			goerrors.Is(err, barretenberg.ErrInvalidPublicInputs) {
 			return &types.ProofVerifyResponse{Verified: false}, nil
 		}
 		return nil, errors.Wrapf(types.ErrInvalidRequest, "verification: %v", err)


### PR DESCRIPTION
## Summary

- **x/zk**: `ProofVerifyUltraHonk` was silently swallowing `barretenberg.ErrInternal` by returning `ProofVerifyResponse{Verified: false}`. A library crash or corrupted vkey now surfaces as an actual error (`"internal verifier error"`) instead of masquerading as a failed-but-valid proof verification.
- **x/jwk**: `DecodeJWT` was missing the `ValidateJWKKeySize(key)` call that both `ValidateJWT` and `VerifyJWS` already perform after parsing the audience JWK. Pre-limit oversized RSA keys stored on-chain before `MaxJWKKeySize = 2048` was introduced could force expensive RSA parse operations through this endpoint.

## Changes

- `x/zk/keeper/query_server.go`: In `ProofVerifyUltraHonk`, extract the `ErrInternal` check before the `ErrVerificationFailed`/`ErrInvalidPublicInputs` check and return `nil, errors.Wrap(err, "internal verifier error")` instead of `Verified: false`.
- `x/jwk/keeper/query_decode_jwt.go`: Add `types.ValidateJWKKeySize(key)` call immediately after `jwk.ParseKey`, matching the identical pattern in `ValidateJWT`.

## Test plan

- [ ] Verify that a `barretenberg.ErrInternal` from `VerifyWithBytes` now causes `ProofVerifyUltraHonk` to return a non-nil error rather than `{Verified: false}`
- [ ] Verify that `ProofVerifyUltraHonk` still returns `{Verified: false}` for `ErrVerificationFailed` and `ErrInvalidPublicInputs`
- [ ] Verify that `DecodeJWT` with an oversized (pre-limit) stored key returns a `codes.FailedPrecondition` error
- [ ] Verify that `DecodeJWT` with a valid-sized key continues to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)