### PR TITLE
feat(dkim): v3 migration for min_rsa_key_bits + test fixes

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -132,7 +132,7 @@ build-linux-arm64 build-linux-amd64 build-darwin-amd64 build-darwin-arm64 build-
 
 build-docker:
 	$(DOCKER) build \
-	  --platform linux/$(GOARCH) 
+	  --platform linux/$(GOARCH) \
 	  --target=$(if $(TARGET),$(TARGET),release) \
 	  --progress=plain \
 	  --build-arg=GORELEASER_IMAGE=$(GORELEASER_IMAGE) \

--- a/x/dkim/keeper/keeper_test.go
+++ b/x/dkim/keeper/keeper_test.go
@@ -351,6 +351,7 @@ func TestKeeperGetParams(t *testing.T) {
 			VkeyIdentifier:     42,
 			MaxPubkeySizeBytes: 4096,
 			PublicInputIndices: types.DefaultPublicInputIndices(),
+			MinRsaKeyBits:      types.DefaultMinRSAKeyBits,
 		}
 		err := f.k.SetParams(f.ctx, customParams)
 		require.NoError(t, err)

--- a/x/dkim/keeper/migrator.go
+++ b/x/dkim/keeper/migrator.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	v2 "github.com/burnt-labs/xion/x/dkim/migrations/v2"
+	v3 "github.com/burnt-labs/xion/x/dkim/migrations/v3"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -19,4 +20,9 @@ func NewMigrator(keeper Keeper) Migrator {
 // Migrate1to2 migrates from version 1 to 2.
 func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 	return v2.MigrateStore(ctx, m.keeper.Params, m.keeper.DkimPubKeys)
+}
+
+// Migrate2to3 migrates from version 2 to 3.
+func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+	return v3.MigrateStore(ctx, m.keeper.Params)
 }

--- a/x/dkim/migrations/v3/migrate.go
+++ b/x/dkim/migrations/v3/migrate.go
@@ -1,0 +1,34 @@
+package v3
+
+import (
+	"cosmossdk.io/collections"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/burnt-labs/xion/x/dkim/types"
+)
+
+// MigrateStore performs in-place migrations for the DKIM module from v2 to v3.
+// This migration sets MinRsaKeyBits on existing params to DefaultMinRSAKeyBits
+// (1024) for chains that were upgraded before the field existed (proto default
+// would otherwise leave it as 0, which fails Params.Validate()).
+func MigrateStore(
+	ctx sdk.Context,
+	paramsCollection collections.Item[types.Params],
+) error {
+	ctx.Logger().Info("Running DKIM module migration from v2 to v3")
+
+	existingParams, err := paramsCollection.Get(ctx)
+	if err != nil {
+		ctx.Logger().Info("No existing params found, setting defaults")
+		return paramsCollection.Set(ctx, types.DefaultParams())
+	}
+
+	if existingParams.MinRsaKeyBits == 0 {
+		existingParams.MinRsaKeyBits = types.DefaultMinRSAKeyBits
+		ctx.Logger().Info("Setting MinRsaKeyBits to default", "value", types.DefaultMinRSAKeyBits)
+	}
+
+	ctx.Logger().Info("DKIM module migration from v2 to v3 completed successfully")
+	return paramsCollection.Set(ctx, existingParams)
+}

--- a/x/dkim/migrations/v3/migrate.go
+++ b/x/dkim/migrations/v3/migrate.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"errors"
+
 	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,8 +22,11 @@ func MigrateStore(
 
 	existingParams, err := paramsCollection.Get(ctx)
 	if err != nil {
-		ctx.Logger().Info("No existing params found, setting defaults")
-		return paramsCollection.Set(ctx, types.DefaultParams())
+		if errors.Is(err, collections.ErrNotFound) {
+			ctx.Logger().Info("No existing params found, setting defaults")
+			return paramsCollection.Set(ctx, types.DefaultParams())
+		}
+		return err
 	}
 
 	if existingParams.MinRsaKeyBits == 0 {

--- a/x/dkim/migrations/v3/migrate_test.go
+++ b/x/dkim/migrations/v3/migrate_test.go
@@ -1,0 +1,100 @@
+package v3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	v3 "github.com/burnt-labs/xion/x/dkim/migrations/v3"
+	"github.com/burnt-labs/xion/x/dkim/types"
+)
+
+func TestMigrateStore(t *testing.T) {
+	encCfg := moduletestutil.MakeTestEncodingConfig()
+	types.RegisterInterfaces(encCfg.InterfaceRegistry)
+
+	key := storetypes.NewKVStoreKey(types.ModuleName)
+	tkey := storetypes.NewTransientStoreKey("transient_test")
+	testCtx := testutil.DefaultContextWithDB(t, key, tkey)
+	ctx := testCtx.Ctx
+
+	storeService := runtime.NewKVStoreService(key)
+	sb := collections.NewSchemaBuilder(storeService)
+
+	paramsCollection := collections.NewItem(sb, types.ParamsKey, "params", codec.CollValue[types.Params](encCfg.Codec))
+
+	_, err := sb.Build()
+	require.NoError(t, err)
+
+	t.Run("existing params with MinRsaKeyBits=0 migrated to default", func(t *testing.T) {
+		// Simulate v2 state where MinRsaKeyBits was not yet a field (proto zero value).
+		oldParams := types.Params{
+			VkeyIdentifier:     1,
+			MaxPubkeySizeBytes: 512,
+			PublicInputIndices: types.DefaultPublicInputIndices(),
+			MinRsaKeyBits:      0,
+		}
+		err := paramsCollection.Set(ctx, oldParams)
+		require.NoError(t, err)
+
+		// Run migration
+		err = v3.MigrateStore(ctx.WithLogger(log.NewNopLogger()), paramsCollection)
+		require.NoError(t, err)
+
+		// Verify MinRsaKeyBits was set to default
+		newParams, err := paramsCollection.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, types.DefaultMinRSAKeyBits, newParams.MinRsaKeyBits)
+		// Other fields should be preserved
+		require.Equal(t, uint64(1), newParams.VkeyIdentifier)
+		require.Equal(t, uint64(512), newParams.MaxPubkeySizeBytes)
+	})
+
+	t.Run("existing params with MinRsaKeyBits already set unchanged", func(t *testing.T) {
+		customMinBits := uint64(2048)
+		existingParams := types.Params{
+			VkeyIdentifier:     2,
+			MaxPubkeySizeBytes: 1024,
+			PublicInputIndices: types.DefaultPublicInputIndices(),
+			MinRsaKeyBits:      customMinBits,
+		}
+		err := paramsCollection.Set(ctx, existingParams)
+		require.NoError(t, err)
+
+		// Run migration
+		err = v3.MigrateStore(ctx.WithLogger(log.NewNopLogger()), paramsCollection)
+		require.NoError(t, err)
+
+		// Verify MinRsaKeyBits was NOT changed
+		newParams, err := paramsCollection.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, customMinBits, newParams.MinRsaKeyBits)
+		// Other fields should be preserved
+		require.Equal(t, uint64(2), newParams.VkeyIdentifier)
+		require.Equal(t, uint64(1024), newParams.MaxPubkeySizeBytes)
+	})
+
+	t.Run("no existing params sets defaults", func(t *testing.T) {
+		// Clear params
+		err := paramsCollection.Remove(ctx)
+		require.NoError(t, err)
+
+		// Run migration
+		err = v3.MigrateStore(ctx.WithLogger(log.NewNopLogger()), paramsCollection)
+		require.NoError(t, err)
+
+		// Verify default params are set
+		newParams, err := paramsCollection.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, types.DefaultParams(), newParams)
+	})
+}

--- a/x/dkim/module.go
+++ b/x/dkim/module.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// ConsensusVersion defines the current x/dkim module consensus version.
-	ConsensusVersion = 2
+	ConsensusVersion = 3
 
 // this line is used by starport scaffolding # simapp/module/const
 )
@@ -146,6 +146,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 
 	m := keeper.NewMigrator(am.keeper)
 	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2); err != nil {
+		panic(err)
+	}
+	if err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2to3); err != nil {
 		panic(err)
 	}
 }

--- a/x/dkim/module_test.go
+++ b/x/dkim/module_test.go
@@ -51,7 +51,7 @@ func TestAppModule_Name(t *testing.T) {
 
 func TestAppModule_ConsensusVersion(t *testing.T) {
 	appModule := setupModule(t)
-	require.Equal(t, uint64(2), appModule.ConsensusVersion())
+	require.Equal(t, uint64(3), appModule.ConsensusVersion())
 }
 
 func TestAppModule_DefaultGenesis(t *testing.T) {

--- a/x/dkim/types/msgs.go
+++ b/x/dkim/types/msgs.go
@@ -226,10 +226,17 @@ func ValidateDkimPubKeysWithRevocation(
 	return nil
 }
 
-// ValidateDkimPubKey validates a DKIM public key entry for use in messages.
+// ValidateDkimPubKey validates a DKIM public key entry for use in messages
+// (called from MsgAddDkimPubKeys.ValidateBasic).
+//
 // Uses ValidateBasicMaxPubKeySizeBytes as a high ceiling since ValidateBasic is
 // stateless and cannot access on-chain params. The msg server will enforce
 // actual param limits and key size requirements via ValidateDkimPubKeysWithRevocation.
+//
+// NOTE: RSA key size is intentionally NOT checked here because the minimum
+// is a governance-configurable on-chain parameter (params.MinRsaKeyBits).
+// ValidateBasic must remain stateless. The msg server enforces key size via
+// ValidateDkimPubKeysWithRevocation after loading params from state.
 func ValidateDkimPubKey(dkimKey DkimPubKey) error {
 	if err := validateDkimPubKeyMetadata(dkimKey); err != nil {
 		return err
@@ -241,16 +248,15 @@ func ValidateDkimPubKey(dkimKey DkimPubKey) error {
 		return err
 	}
 
-	// Only validate that it parses as RSA - don't enforce key size limits here
-	// since ValidateBasic should be stateless. The msg server will enforce
-	// size requirements via ValidateDkimPubKeysWithRevocation.
+	// Only validate that it parses as RSA — key size is not checked here
+	// (see function comment above for rationale).
 	_, err = ParseRSAPublicKey(pubKeyBytes)
 	return err
 }
 
 // ValidateRSAPubKey validates that the string is a valid base64-encoded RSA public key
-// meeting the DKIM minimum key size (MinDKIMRSAKeyBits). Use ValidateRSAKeySize
-// separately to enforce the stricter governance minimum (MinRSAKeyBits).
+// meeting the default minimum key size (DefaultMinRSAKeyBits = 1024). Use
+// ValidateRSAKeySize separately to enforce the stricter hardcoded minimum (MinRSAKeyBits = 2048).
 func ValidateRSAPubKey(pubKeyStr string) error {
 	pubKeyBytes, err := DecodePubKey(pubKeyStr)
 	if err != nil {
@@ -262,8 +268,8 @@ func ValidateRSAPubKey(pubKeyStr string) error {
 		return err
 	}
 
-	if rsaPub.N.BitLen() < MinDKIMRSAKeyBits {
-		return errors.Wrapf(ErrInvalidPubKey, "RSA key size %d bits is below minimum %d", rsaPub.N.BitLen(), MinDKIMRSAKeyBits)
+	if rsaPub.N.BitLen() < int(DefaultMinRSAKeyBits) {
+		return errors.Wrapf(ErrInvalidPubKey, "RSA key size %d bits is below minimum %d", rsaPub.N.BitLen(), DefaultMinRSAKeyBits)
 	}
 	return nil
 }

--- a/x/dkim/types/msgs_test.go
+++ b/x/dkim/types/msgs_test.go
@@ -474,6 +474,12 @@ func TestValidateDkimPubKeysWithRevocation(t *testing.T) {
 	t.Run("1024-bit key accepted for message path (Yahoo s1024 compatibility)", func(t *testing.T) {
 		// MinRSAKeyBits is set to 1024 to support legacy providers like Yahoo (s1024 selector).
 		// 1024-bit keys are low-assurance and expected to be rotated when providers upgrade.
+		// Use a local params with MinRsaKeyBits explicitly set so the fallback to
+		// MinRSAKeyBits (2048) is not triggered.
+		localParams := types.Params{
+			MaxPubkeySizeBytes: 2048,
+			MinRsaKeyBits:      types.DefaultMinRSAKeyBits,
+		}
 		smallKey, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 		require.NoError(t, err)
 		pkixBytes, err := x509.MarshalPKIXPublicKey(&smallKey.PublicKey)
@@ -486,7 +492,7 @@ func TestValidateDkimPubKeysWithRevocation(t *testing.T) {
 			Version:  types.Version_VERSION_DKIM1_UNSPECIFIED,
 			KeyType:  types.KeyType_KEY_TYPE_RSA_UNSPECIFIED,
 		}
-		err = types.ValidateDkimPubKeysWithRevocation(context.Background(), []types.DkimPubKey{key}, params, nil, true)
+		err = types.ValidateDkimPubKeysWithRevocation(context.Background(), []types.DkimPubKey{key}, localParams, nil, true)
 		require.NoError(t, err)
 	})
 }

--- a/x/dkim/types/pubkey.go
+++ b/x/dkim/types/pubkey.go
@@ -9,13 +9,10 @@ import (
 	errorsmod "cosmossdk.io/errors"
 )
 
-// MinDKIMRSAKeyBits is the minimum RSA key size for any valid DKIM key (per RFC 6376).
-// This allows legacy 1024-bit keys such as Yahoo's s1024 selector.
-const MinDKIMRSAKeyBits = 1024
-
-// MinRSAKeyBits is the hardcoded fallback minimum RSA key size used in stateless
-// ValidateBasic paths and as a safety net when params.MinRsaKeyBits is unset.
-// The governance-configurable minimum is params.MinRsaKeyBits (default 1024).
+// MinRSAKeyBits is the hardcoded fallback minimum RSA key size used in
+// ValidateDkimPubKeysWithRevocation when params.MinRsaKeyBits is unset (zero).
+// The governance-configurable minimum is params.MinRsaKeyBits (default 1024,
+// defined as DefaultMinRSAKeyBits in params.go).
 const MinRSAKeyBits = 2048
 
 // ParseRSAPublicKey parses PKIX or PKCS#1-encoded RSA public key bytes.
@@ -41,9 +38,9 @@ func ParseRSAPublicKey(pubKeyBytes []byte) (*rsa.PublicKey, error) {
 	return rsaPub, nil
 }
 
-// ValidateRSAKeySize checks that the RSA key meets the hardcoded minimum bit length.
-// Used in stateless ValidateBasic paths that cannot access on-chain params.
-// The msg server uses params.MinRsaKeyBits for the governance-configurable check.
+// ValidateRSAKeySize checks that the RSA key meets the hardcoded minimum bit length
+// (MinRSAKeyBits = 2048). This is the fallback used by ValidateDkimPubKeysWithRevocation
+// when params.MinRsaKeyBits is unset. It is NOT called from any ValidateBasic path.
 func ValidateRSAKeySize(key *rsa.PublicKey) error {
 	if key == nil || key.N == nil {
 		return errorsmod.Wrap(ErrInvalidPubKey, "RSA public key is nil")

--- a/x/dkim/types/pubkey_test.go
+++ b/x/dkim/types/pubkey_test.go
@@ -70,11 +70,12 @@ func TestValidateRSAKeySize(t *testing.T) {
 		require.Contains(t, err.Error(), "RSA public key is nil")
 	})
 
-	t.Run("accepts 1024-bit key (Yahoo s1024 compatibility)", func(t *testing.T) {
+	t.Run("rejects 1024-bit key", func(t *testing.T) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 		require.NoError(t, err)
 		err = types.ValidateRSAKeySize(&key.PublicKey)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "below minimum")
 	})
 
 	t.Run("accepts 2048-bit key", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #525. The governance-configurable `min_rsa_key_bits` param was already merged into `release/v29` via #525. This PR adds the necessary migration and fixes test issues introduced by the interaction between the simple constant change and the governance-param approach.

- **v3 migration** (`x/dkim/migrations/v3/migrate.go`): Sets `MinRsaKeyBits = DefaultMinRSAKeyBits (1024)` on existing chains where the field is 0 (proto default). Without this, `Params.Validate()` rejects 0, breaking `xiond export`/re-import and any `MsgUpdateParams` proposal that omits the field. Uses `collections.ErrNotFound` to distinguish missing params from decode errors — avoids silently overwriting valid state with defaults on corruption.
- **Migration test** (`x/dkim/migrations/v3/migrate_test.go`): Three cases — MinRsaKeyBits=0 migrated to default, already-set value preserved, no params sets defaults.
- **Broken test fixes**: Two tests had assertions left over from when `MinRSAKeyBits=1024` (the simple constant approach). After the governance-param reset of `MinRSAKeyBits=2048`, these tests would fail:
  - `msgs_test.go`: 1024-bit subtest now uses a local `params` with `MinRsaKeyBits: DefaultMinRSAKeyBits` so the `NoError` assertion is correct
  - `pubkey_test.go`: `ValidateRSAKeySize` test reverted to `require.Error` since the function uses the 2048 hardcoded fallback
- **Constant consolidation**: Removed duplicate `MinDKIMRSAKeyBits`; `ValidateRSAPubKey` now uses `DefaultMinRSAKeyBits`
- **Comment fixes**: `ValidateRSAKeySize` comment updated to accurately describe its role (fallback, not called from ValidateBasic); stateless gap in `ValidateDkimPubKey` documented

## Test plan

- [ ] `go test ./x/dkim/...` passes
- [ ] Migration test covers all three cases
- [ ] No broken test assertions for 1024-bit key handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)