### PR TITLE
fix: align Stargate whitelist gas policy with v28

### DIFF
--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -205,6 +205,8 @@ func (k Querier) Authenticate(c context.Context, req *types.QueryAuthenticateReq
 	}
 	indices := params.PublicInputIndices
 
+	// No gas is charged for this Stargate-whitelisted query — proof size and input limits
+	// serve as the DoS governors, consistent with v28 behavior.
 	// Reject oversized proof blobs before any deserialization to prevent allocator DoS.
 	// A valid Circom Groth16/BN254 proof is ~350–500 bytes of JSON; anything beyond
 	// MaxDKIMProofSizeBytes is not a legitimate proof.

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -11,7 +11,6 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/burnt-labs/xion/x/zk/types"
@@ -45,6 +44,9 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 		return nil, err
 	}
 
+	// No gas is charged for this whitelisted query — size limits (MaxGroth16ProofSizeBytes,
+	// MaxGroth16PublicInputSizeBytes) and governance-controlled ceilings (MaxAllowedProofOrInputSizeBytes)
+	// serve as the DoS governors, consistent with v28 behavior.
 	if uint64(len(req.Proof)) > params.MaxGroth16ProofSizeBytes {
 		return nil, errors.Wrapf(
 			types.ErrProofTooLarge,
@@ -71,12 +73,6 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 			params.MaxGroth16PublicInputSizeBytes,
 		)
 	}
-
-	// Charge gas before executing the BN254 pairing check. Proof verification is
-	// computationally expensive and must be metered to prevent a single query from
-	// consuming unbounded node resources.
-	sdkCtx := sdk.UnwrapSDKContext(c)
-	sdkCtx.GasMeter().ConsumeGas(types.ProofVerifyGas, "zk/ProofVerify: bn254 pairing")
 
 	snarkProof, err := parser.UnmarshalCircomProofJSON(req.Proof)
 	if err != nil {
@@ -122,6 +118,9 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 		return nil, err
 	}
 
+	// No gas is charged for this whitelisted query — size limits (MaxUltraHonkProofSizeBytes,
+	// MaxUltraHonkPublicInputSizeBytes) and governance-controlled ceilings (MaxAllowedProofOrInputSizeBytes)
+	// serve as the DoS governors, consistent with v28 behavior.
 	if uint64(len(req.GetProof())) > params.MaxUltraHonkProofSizeBytes {
 		return nil, errors.Wrapf(
 			types.ErrProofTooLarge,

--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -29,11 +29,6 @@ const (
 	// For UltraHonk, public inputs are provided as raw bytes.
 	DefaultMaxUltraHonkPublicInputSizeBytes uint64 = 10 * 1024 // 10 KiB
 
-	// ProofVerifyGas is the flat gas cost charged per BN254 proof verification.
-	// BN254 pairing checks are computationally expensive; this cost bounds the
-	// number of verifications an account can submit per block under its gas limit.
-	ProofVerifyGas uint64 = 500_000
-
 	// MinProofOrInputSizeBytes is the minimum value governance may set for any
 	// proof or public-input size parameter (must be at least 1 byte).
 	MinProofOrInputSizeBytes uint64 = 1


### PR DESCRIPTION
## Summary

- Removes gas metering from `ProofVerify` (Groth16) to restore v28 behavior — adding gas to whitelisted endpoints was unintentional and would break deployed contracts with fixed gas budgets
- Adds explicit design-intent comments to all three whitelisted crypto query endpoints (`ProofVerify`, `ProofVerifyUltraHonk`, `dkim/Authenticate`) explaining that size governors replace gas metering
- Removes unused `ProofVerifyGas` constant from `x/zk/types/params.go`

**Policy clarification:** All Stargate-whitelisted query endpoints use byte-size limits as their DoS protection, consistent with `ValidateJWT`. This is intentional — gas metering on whitelisted endpoints would silently break any deployed contract that calls them with a fixed gas budget.