### PR TITLE
docs: backport Stargate whitelist no-gas policy comments to release/v28

### DIFF
--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -205,6 +205,10 @@ func (k Querier) Authenticate(c context.Context, req *types.QueryAuthenticateReq
 	}
 	indices := params.PublicInputIndices
 
+	// No gas is charged for this Stargate-whitelisted query. DoS protection is provided by
+	// proof size and public input count limits (governance-managed). This is intentional
+	// and consistent with ValidateJWT — adding gas to whitelisted endpoints would break deployed
+	// CosmWasm contracts that call them with fixed gas budgets.
 	if uint64(len(req.PublicInputs)) < indices.MinLength {
 		return nil, errors.Wrapf(types.ErrNotEnoughPublicInputs, "insufficient public inputs, need at least %d elements, got %d", indices.MinLength, len(req.PublicInputs))
 	}

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -34,6 +34,10 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 		return nil, errors.Wrap(types.ErrInvalidRequest, "proof cannot be empty")
 	}
 
+	// No gas is charged for this Stargate-whitelisted query. DoS protection is provided by
+	// proof size validation and vkey lookup controls (governance-managed). This is intentional
+	// and consistent with ValidateJWT — adding gas to whitelisted endpoints would break deployed
+	// CosmWasm contracts that call them with fixed gas budgets.
 	snarkProof, err := parser.UnmarshalCircomProofJSON(req.Proof)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Backports design-intent comments from PR #538 (`release/v29`) to `release/v28`
- Adds explicit no-gas policy comments to `ProofVerify` (`x/zk`) and `Authenticate` (`x/dkim`) — the two Stargate-whitelisted crypto query endpoints present in v28

**Policy:** All Stargate-whitelisted query endpoints intentionally have no gas metering. Size governors (proof size limits, public input count limits, governance-controlled) provide DoS protection, consistent with `ValidateJWT`. Adding gas to whitelisted endpoints would silently break any deployed CosmWasm contract that calls them with a fixed gas budget.

## Files Changed

- `x/zk/keeper/query_server.go` — comment on `ProofVerify`
- `x/dkim/keeper/query_server.go` — comment on `dkim/Authenticate`

## Test plan

- [ ] Comment-only change; no functional diff — confirm `git diff release/v28...HEAD` shows only added comment lines
- [ ] Verify `make build` passes on the branch
- [ ] Verify `make test` passes on the branch