### PR TITLE
chore: hide generated proto diffs and require DevOps review for coverage gates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.pb.go linguist-generated=true
+*.pb.gw.go linguist-generated=true
+*.pulsar.go linguist-generated=true
+client/docs/static/swagger.json linguist-generated=true
+client/docs/static/openapi.json linguist-generated=true
+
+# Keep source proto files reviewable
+proto/**/*.proto linguist-generated=false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,3 +32,12 @@
 .github/ @burnt-labs/burnt-devops
 .goreleaser @burnt-labs/burnt-devops
 Dockerfile @burnt-labs/burnt-devops
+
+# Coverage requirements and gates must have DevOps sign-off
+.coveragerc @burnt-labs/burnt-devops
+.codecov.yml @burnt-labs/burnt-devops
+make/coverage.mk @burnt-labs/burnt-devops
+make/test.mk @burnt-labs/burnt-devops
+scripts/coverage-analyze.sh @burnt-labs/burnt-devops
+.github/workflows/tests.yaml @burnt-labs/burnt-devops
+.github/workflows/build-test.yaml @burnt-labs/burnt-devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,5 +39,3 @@ Dockerfile @burnt-labs/burnt-devops
 make/coverage.mk @burnt-labs/burnt-devops
 make/test.mk @burnt-labs/burnt-devops
 scripts/coverage-analyze.sh @burnt-labs/burnt-devops
-.github/workflows/tests.yaml @burnt-labs/burnt-devops
-.github/workflows/build-test.yaml @burnt-labs/burnt-devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,10 +32,10 @@
 .github/ @burnt-labs/burnt-devops
 .goreleaser @burnt-labs/burnt-devops
 Dockerfile @burnt-labs/burnt-devops
+Makefile @burnt-labs/burnt-devops
+make/ @burnt-labs/burnt-devops
+scripts/ @burnt-labs/burnt-devops
 
 # Coverage requirements and gates must have DevOps sign-off
 .coveragerc @burnt-labs/burnt-devops
 .codecov.yml @burnt-labs/burnt-devops
-make/coverage.mk @burnt-labs/burnt-devops
-make/test.mk @burnt-labs/burnt-devops
-scripts/coverage-analyze.sh @burnt-labs/burnt-devops


### PR DESCRIPTION
## Summary
- Mark files generated by `make proto-all` as generated in GitHub diffs via `.gitattributes`
- Keep source proto files (`proto/**/*.proto`) reviewable
- Add explicit `CODEOWNERS` rules so coverage-requirement and coverage-gating files require DevOps sign-off

## Why
- Reduce PR noise from generated artifacts
- Ensure policy changes to test coverage requirements are reviewed by DevOps

## Included coverage-governance paths
- `.coveragerc`
- `.codecov.yml`
- `make/coverage.mk`
- `make/test.mk`
- `scripts/coverage-analyze.sh`
- `.github/workflows/tests.yaml`
- `.github/workflows/build-test.yaml`
