### PR TITLE
zk: restore proof-system vkey checks in ValidateBasic

### DIFF
--- a/x/zk/types/msgs.go
+++ b/x/zk/types/msgs.go
@@ -55,6 +55,12 @@ func (m *MsgAddVKey) ValidateBasic() error {
 		return fmt.Errorf("unsupported proof_system: %v", proofSystem)
 	}
 
+	// Apply proof-system aware structural checks at CheckTx time to reduce
+	// malformed-vkey mempool spam while keeping keeper-side validation authoritative.
+	if err := ValidateVKeyForProofSystem(m.VkeyBytes, DefaultMaxVKeySizeBytes, proofSystem); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -86,6 +92,12 @@ func (m *MsgUpdateVKey) ValidateBasic() error {
 		proofSystem != ProofSystem_PROOF_SYSTEM_GROTH16_GNARK &&
 		proofSystem != ProofSystem_PROOF_SYSTEM_ULTRA_HONK_ZK {
 		return fmt.Errorf("unsupported proof_system: %v", proofSystem)
+	}
+
+	// Apply proof-system aware structural checks at CheckTx time to reduce
+	// malformed-vkey mempool spam while keeping keeper-side validation authoritative.
+	if err := ValidateVKeyForProofSystem(m.VkeyBytes, DefaultMaxVKeySizeBytes, proofSystem); err != nil {
+		return err
 	}
 
 	return nil

--- a/x/zk/types/msgs.go
+++ b/x/zk/types/msgs.go
@@ -57,7 +57,7 @@ func (m *MsgAddVKey) ValidateBasic() error {
 
 	// Apply proof-system aware structural checks at CheckTx time to reduce
 	// malformed-vkey mempool spam while keeping keeper-side validation authoritative.
-	if err := ValidateVKeyForProofSystem(m.VkeyBytes, DefaultMaxVKeySizeBytes, proofSystem); err != nil {
+	if err := ValidateVKeyForProofSystem(m.VkeyBytes, MaxAllowedVKeySizeBytes, proofSystem); err != nil {
 		return err
 	}
 
@@ -96,7 +96,7 @@ func (m *MsgUpdateVKey) ValidateBasic() error {
 
 	// Apply proof-system aware structural checks at CheckTx time to reduce
 	// malformed-vkey mempool spam while keeping keeper-side validation authoritative.
-	if err := ValidateVKeyForProofSystem(m.VkeyBytes, DefaultMaxVKeySizeBytes, proofSystem); err != nil {
+	if err := ValidateVKeyForProofSystem(m.VkeyBytes, MaxAllowedVKeySizeBytes, proofSystem); err != nil {
 		return err
 	}
 

--- a/x/zk/types/msgs_test.go
+++ b/x/zk/types/msgs_test.go
@@ -91,14 +91,14 @@ func TestMsgAddVKey_ValidateBasic(t *testing.T) {
 		require.Contains(t, err.Error(), "vkey_bytes cannot be empty")
 	})
 
-	t.Run("non-empty arbitrary vkey bytes", func(t *testing.T) {
+	t.Run("non-empty arbitrary vkey bytes are rejected", func(t *testing.T) {
 		msg := &types.MsgAddVKey{
 			Authority: validAuthority,
 			Name:      "test-vkey",
 			VkeyBytes: []byte("arbitrary-non-empty-bytes"),
 		}
 		err := msg.ValidateBasic()
-		require.NoError(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -168,6 +168,16 @@ func TestMsgUpdateVKey_ValidateBasic(t *testing.T) {
 		err := msg.ValidateBasic()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "vkey_bytes cannot be empty")
+	})
+
+	t.Run("non-empty arbitrary vkey bytes are rejected", func(t *testing.T) {
+		msg := &types.MsgUpdateVKey{
+			Authority: validAuthority,
+			Name:      "test-vkey",
+			VkeyBytes: []byte("arbitrary-non-empty-bytes"),
+		}
+		err := msg.ValidateBasic()
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
## Summary
- restore proof-system-aware vkey validation checks in `MsgAddVKey.ValidateBasic`
- apply the same checks in `MsgUpdateVKey.ValidateBasic`
- keep keeper-side validation as the authoritative full validation layer

## Why
`ValidateBasic` had been relaxed to only verify enum shape and basic fields. That weakens mempool/checkTx filtering for malformed verification keys. This change restores lightweight structural checks at `ValidateBasic` time while preserving full keeper validation.

## Changes
- `x/zk/types/msgs.go`
  - `MsgAddVKey.ValidateBasic` now calls `ValidateVKeyForProofSystem(m.VkeyBytes, DefaultMaxVKeySizeBytes, proofSystem)`
  - `MsgUpdateVKey.ValidateBasic` now calls the same helper
- `x/zk/types/msgs_test.go`
  - update expectations so arbitrary non-empty vkey bytes are rejected in add/update ValidateBasic paths

## Validation
- ran: `go test ./x/zk/types/...`
- result: pass
