### PR TITLE
fix(zk,dkim): add panic recovery guards around external crypto library calls

### DIFF
--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -6,15 +6,14 @@ import (
 	"math/big"
 
 	"github.com/vocdoni/circom2gnark/parser"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/burnt-labs/xion/x/dkim/types"
 )

--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -13,6 +13,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/burnt-labs/xion/x/dkim/types"
 )
 
@@ -307,17 +310,29 @@ func (k Querier) Authenticate(c context.Context, req *types.QueryAuthenticateReq
 		return nil, errors.Wrapf(types.ErrInvalidEmailSubject, "email subject validation failed: %s", emailSubjectFromPublicInputsString)
 	}
 
-	snarkProof, err := parser.UnmarshalCircomProofJSON(req.Proof)
-	if err != nil {
-		return nil, err
-	}
+	// Wrap circom2gnark/gnark calls with panic recovery — same risk as the ZK
+	// ProofVerify path: malformed proofs can trigger panics in the gnark library.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = status.Errorf(codes.Internal, "panic during dkim proof verification: %v", r)
+			}
+		}()
 
-	vkey, err := k.ZkKeeper.GetCircomVKeyByID(c, params.VkeyIdentifier)
-	if err != nil {
-		return nil, err
-	}
+		var snarkProof *parser.CircomProof
+		snarkProof, err = parser.UnmarshalCircomProofJSON(req.Proof)
+		if err != nil {
+			return
+		}
 
-	verified, err = k.ZkKeeper.Verify(c, snarkProof, vkey, &req.PublicInputs)
+		var vkey *parser.CircomVerificationKey
+		vkey, err = k.ZkKeeper.GetCircomVKeyByID(c, params.VkeyIdentifier)
+		if err != nil {
+			return
+		}
+
+		verified, err = k.ZkKeeper.Verify(c, snarkProof, vkey, &req.PublicInputs)
+	}()
 	if err != nil {
 		return nil, err
 	}

--- a/x/dkim/keeper/query_server.go
+++ b/x/dkim/keeper/query_server.go
@@ -311,10 +311,12 @@ func (k Querier) Authenticate(c context.Context, req *types.QueryAuthenticateReq
 
 	// Wrap circom2gnark/gnark calls with panic recovery — same risk as the ZK
 	// ProofVerify path: malformed proofs can trigger panics in the gnark library.
+	sdkCtx := sdk.UnwrapSDKContext(c)
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				err = status.Errorf(codes.Internal, "panic during dkim proof verification: %v", r)
+				sdkCtx.Logger().Error("panic during dkim proof verification", "panic", r)
+				err = status.Error(codes.Internal, "internal error during dkim proof verification")
 			}
 		}()
 

--- a/x/dkim/types/genesis_test.go
+++ b/x/dkim/types/genesis_test.go
@@ -54,7 +54,6 @@ func TestGenesisState_Validate(t *testing.T) {
 					VkeyIdentifier:     uint64(42),
 					MaxPubkeySizeBytes: types.DefaultMaxPubKeySizeBytes,
 					PublicInputIndices: types.DefaultPublicInputIndices(),
-
 				},
 			},
 			valid: true,

--- a/x/dkim/types/poseidon.go
+++ b/x/dkim/types/poseidon.go
@@ -197,13 +197,19 @@ func ComputePoseidonHash(pub string) (*big.Int, error) {
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				hashErr = errors.Wrap(sdkError.ErrInvalidRequest, fmt.Sprintf("panic during poseidon hash: %v", r))
+				// Do not expose the recovered panic value in the returned error
+				// to avoid leaking internal details or unbounded error sizes.
+				_ = r
+				hashErr = errors.Wrap(sdkError.ErrInvalidRequest, "panic during poseidon hash")
 			}
 		}()
 		hash, hashErr = poseidon.Hash(pubKeyInputBigInt)
 	}()
 	if hashErr != nil {
-		return nil, errors.Wrap(sdkError.ErrInvalidRequest, hashErr.Error())
+		// hashErr may already be an SDK error (e.g. from the panic recovery
+		// above), so return it directly to avoid double-wrapping, which would
+		// both duplicate error prefixes and break errors.Is checks.
+		return nil, hashErr
 	}
 	return hash, nil
 }

--- a/x/dkim/types/poseidon.go
+++ b/x/dkim/types/poseidon.go
@@ -188,9 +188,22 @@ func ComputePoseidonHash(pub string) (*big.Int, error) {
 	modulusBytes := BigIntToChunkedBytes(modulus, CircomBigintN, CircomBigintK)
 	// prepare the pubkey for hashing
 	pubKeyInputBigInt := PreparePubkeyForHashing(modulusBytes, CircomBigintN, CircomBigintK)
-	hash, err := poseidon.Hash(pubKeyInputBigInt)
-	if err != nil {
-		return nil, errors.Wrap(sdkError.ErrInvalidRequest, err.Error())
+	// Wrap poseidon.Hash with panic recovery — the go-iden3-crypto poseidon
+	// implementation can panic on zero-denominator inputs in the permutation.
+	var (
+		hash    *big.Int
+		hashErr error
+	)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				hashErr = errors.Wrap(sdkError.ErrInvalidRequest, fmt.Sprintf("panic during poseidon hash: %v", r))
+			}
+		}()
+		hash, hashErr = poseidon.Hash(pubKeyInputBigInt)
+	}()
+	if hashErr != nil {
+		return nil, errors.Wrap(sdkError.ErrInvalidRequest, hashErr.Error())
 	}
 	return hash, nil
 }

--- a/x/zk/keeper/keeper.go
+++ b/x/zk/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -233,11 +234,26 @@ func (k *Keeper) Verify(ctx context.Context, proof *parser.CircomProof, vkey *pa
 		}
 	}
 
-	gnarkProof, err := parser.ConvertCircomToGnark(vkey, proof, *inputs)
-	if err != nil {
-		return false, err
-	}
-	return parser.VerifyProof(gnarkProof)
+	// Wrap gnark calls with panic recovery — circom2gnark/gnark may panic on
+	// malformed proofs or VKeys that pass JSON parsing but have invalid curve points.
+	var (
+		verified bool
+		verifyErr error
+	)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				verifyErr = fmt.Errorf("panic during groth16 verification: %v", r)
+			}
+		}()
+		gnarkProof, err := parser.ConvertCircomToGnark(vkey, proof, *inputs)
+		if err != nil {
+			verifyErr = err
+			return
+		}
+		verified, verifyErr = parser.VerifyProof(gnarkProof)
+	}()
+	return verified, verifyErr
 }
 
 // AddVKey adds a new verification key to the store.

--- a/x/zk/keeper/keeper.go
+++ b/x/zk/keeper/keeper.go
@@ -237,7 +237,7 @@ func (k *Keeper) Verify(ctx context.Context, proof *parser.CircomProof, vkey *pa
 	// Wrap gnark calls with panic recovery — circom2gnark/gnark may panic on
 	// malformed proofs or VKeys that pass JSON parsing but have invalid curve points.
 	var (
-		verified bool
+		verified  bool
 		verifyErr error
 	)
 	func() {

--- a/x/zk/keeper/keeper.go
+++ b/x/zk/keeper/keeper.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -243,7 +242,8 @@ func (k *Keeper) Verify(ctx context.Context, proof *parser.CircomProof, vkey *pa
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				verifyErr = fmt.Errorf("panic during groth16 verification: %v", r)
+				k.logger.Error("panic during groth16 verification", "panic", r)
+				verifyErr = errors.Wrap(types.ErrInvalidRequest, "internal error during proof verification")
 			}
 		}()
 		gnarkProof, err := parser.ConvertCircomToGnark(vkey, proof, *inputs)

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -15,6 +15,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types/query"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/burnt-labs/xion/x/zk/types"
 )
 
@@ -207,34 +210,61 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 		chunks[i] = publicInputs[start : start+barretenberg.FieldElementSize]
 	}
 
-	vk, err := barretenberg.ParseVerificationKey(vkey.KeyBytes)
-	if err != nil {
-		return nil, errors.Wrapf(types.ErrInvalidVKey, "ultrahonk vkey: %v", err)
-	}
-	defer vk.Close()
+	// Wrap all Barretenberg CGo calls with panic recovery.
+	// A panic in the C++ layer propagates as a Go panic through CGo; while a
+	// true SIGSEGV cannot be caught here, Go-level panics from the CGo wrapper
+	// (e.g. nil-dereference, bounds check) are recoverable and must not crash
+	// the validator.
+	var (
+		resp    *types.ProofVerifyUltraHonkResponse
+		callErr error
+	)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				callErr = status.Errorf(codes.Internal, "panic during ultrahonk verification: %v", r)
+			}
+		}()
 
-	proof, err := barretenberg.ParseProof(req.GetProof())
-	if err != nil {
-		return nil, errors.Wrapf(types.ErrInvalidRequest, "proof: %v", err)
-	}
-
-	verifier, err := barretenberg.NewVerifier(vk)
-	if err != nil {
-		return nil, err
-	}
-	defer verifier.Close()
-
-	verified, err := verifier.VerifyWithBytes(proof, chunks)
-	if err != nil {
-		if goerrors.Is(err, barretenberg.ErrVerificationFailed) ||
-			goerrors.Is(err, barretenberg.ErrInvalidPublicInputs) ||
-			goerrors.Is(err, barretenberg.ErrInternal) {
-			return &types.ProofVerifyUltraHonkResponse{Verified: false}, nil
+		vk, e := barretenberg.ParseVerificationKey(vkey.KeyBytes)
+		if e != nil {
+			callErr = errors.Wrapf(types.ErrInvalidVKey, "ultrahonk vkey: %v", e)
+			return
 		}
-		return nil, errors.Wrapf(types.ErrInvalidRequest, "verification: %v", err)
+		defer vk.Close()
+
+		bproof, e := barretenberg.ParseProof(req.GetProof())
+		if e != nil {
+			callErr = errors.Wrapf(types.ErrInvalidRequest, "proof: %v", e)
+			return
+		}
+
+		verifier, e := barretenberg.NewVerifier(vk)
+		if e != nil {
+			callErr = e
+			return
+		}
+		defer verifier.Close()
+
+		verified, e := verifier.VerifyWithBytes(bproof, chunks)
+		if e != nil {
+			if goerrors.Is(e, barretenberg.ErrVerificationFailed) ||
+				goerrors.Is(e, barretenberg.ErrInvalidPublicInputs) ||
+				goerrors.Is(e, barretenberg.ErrInternal) {
+				resp = &types.ProofVerifyUltraHonkResponse{Verified: false}
+				return
+			}
+			callErr = errors.Wrapf(types.ErrInvalidRequest, "verification: %v", e)
+			return
+		}
+		resp = &types.ProofVerifyUltraHonkResponse{Verified: verified}
+	}()
+	if callErr != nil {
+		return nil, callErr
 	}
-	return &types.ProofVerifyUltraHonkResponse{Verified: verified}, nil
+	return resp, nil
 }
+
 
 // VKey queries a verification key by ID
 func (q Querier) VKey(goCtx context.Context, req *types.QueryVKeyRequest) (*types.QueryVKeyResponse, error) {

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -265,7 +265,6 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 	return resp, nil
 }
 
-
 // VKey queries a verification key by ID
 func (q Querier) VKey(goCtx context.Context, req *types.QueryVKeyRequest) (*types.QueryVKeyResponse, error) {
 	if req == nil {

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/burnt-labs/barretenberg-go/barretenberg"
 	"github.com/vocdoni/circom2gnark/parser"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/burnt-labs/xion/x/zk/types"
 )

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -221,7 +221,8 @@ func (q Querier) ProofVerifyUltraHonk(c context.Context, req *types.QueryVerifyU
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				callErr = status.Errorf(codes.Internal, "panic during ultrahonk verification: %v", r)
+				q.logger.Error("panic during ultrahonk verification", "panic", r)
+				callErr = status.Error(codes.Internal, "internal error during proof verification")
 			}
 		}()
 


### PR DESCRIPTION
## Summary

The JWK module wraps `lestrrat-go/jwx` calls with `defer/recover` after experiencing panics in production. The same risk exists unguarded in the ZK and DKIM modules — this PR adds the same defensive pattern to all affected call sites.

**Affected libraries:**
- `vocdoni/circom2gnark` / `gnark` (BN254 Groth16) — can panic on malformed proofs or VKeys that pass JSON parsing but have invalid curve points
- `burnt-labs/barretenberg-go` (UltraHonk, CGo) — Go-level panics from the CGo wrapper would crash the validator
- `iden3/go-iden3-crypto/poseidon` — can panic on zero-denominator inputs in the permutation

**Changes:**
- `x/zk/keeper/keeper.go` (`Verify`): wrap `ConvertCircomToGnark` + `VerifyProof`
- `x/zk/keeper/query_server.go` (`ProofVerifyUltraHonk`): wrap all Barretenberg CGo calls
- `x/dkim/keeper/query_server.go` (`Authenticate`): wrap `UnmarshalCircomProofJSON` + `ZkKeeper.Verify`
- `x/dkim/types/poseidon.go` (`ComputePoseidonHash`): wrap `poseidon.Hash` — called from msg server and genesis paths

**Note on Barretenberg:** A true C++ SIGSEGV cannot be caught by Go's `defer/recover`. The guard here catches Go-level panics from the CGo wrapper (nil dereference, bounds check, etc.). The existing size limits (20KB proof, 10KB inputs) remain the primary DoS governor for the C++ layer.

## Test plan
- [x] Existing ZK and DKIM unit tests pass
- [x] Verify that invalid proof inputs return errors (not panics) in each guarded path
- [x] Confirm `ProofVerifyUltraHonk` returns `codes.Internal` on panic rather than crashing the node

All 53 CI checks passing (Go unit tests, lint, build linux/amd64 + arm64, 47 E2E tests including ZK and DKIM suites).