### PR TITLE
fix: only clear local min-gas-prices in bypass path when non-zero

### DIFF
--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -109,7 +109,7 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 		// zero-fee bypass transactions (e.g. IBC relayer packets).
 		// When a non-zero fee is provided, keep the original context so
 		// the fee is still validated against the local minimum.
-		if feeCoins.IsZero() {
+		if feeCoins.IsZero() && !ctx.MinGasPrices().IsZero() {
 			return next(ctx.WithMinGasPrices(sdk.DecCoins{}), tx, simulate)
 		}
 		return next(ctx, tx, simulate)


### PR DESCRIPTION
## Summary

The globalfee `FeeWithBypassDecorator` allows certain message types (IBC relayer packets, governance proposals, etc.) to bypass the normal minimum fee requirements. This bypass path is essential for infrastructure transactions that must succeed even when a transaction sender cannot or should not pay fees.

## Bug

When a bypass-eligible transaction provides zero fees, the original `sdk.Context` still carries the validator's locally configured `minimum-gas-prices` from `app.toml`. Downstream ante decorators inspect `ctx.MinGasPrices()` and, seeing a non-zero local minimum, reject the zero-fee transaction — even though `FeeWithBypassDecorator` explicitly intended to permit it.

The previous fix addressed this by unconditionally clearing `MinGasPrices` whenever a bypass tx provides zero fees:

```go
if feeCoins.IsZero() {
    return next(ctx.WithMinGasPrices(sdk.DecCoins{}), tx, simulate)
}
```

However, this unconditional clear changes behavior on validators configured with `minimum-gas-prices = ""` (the default, zero). On those nodes, the context already has zero gas prices, so overwriting it with an empty `sdk.DecCoins{}` alters the context object unnecessarily. This broke inflation and fee accounting tests that rely on the context being unmodified when no local minimum is configured.

## Fix

Add a guard so the clear only happens when it is actually needed — i.e., when the validator's local `minimum-gas-prices` is non-zero:

```go
if feeCoins.IsZero() && !ctx.MinGasPrices().IsZero() {
    return next(ctx.WithMinGasPrices(sdk.DecCoins{}), tx, simulate)
}
```

The `!ctx.MinGasPrices().IsZero()` guard ensures:

- **Validators with a non-zero local minimum** (`minimum-gas-prices = "0.001uxion"` in `app.toml`): the bypass path still clears the local minimum so downstream decorators do not block legitimately zero-fee bypass transactions.
- **Validators with zero or unset local minimum** (the default): the context is passed through unmodified, preserving existing behavior for fee accounting, inflation calculations, and any downstream logic that depends on the context state.

This is a narrower, targeted fix that preserves the security intent of the bypass path — zero-fee IBC relayer and governance transactions continue to work on validators with strict local fee floors — while leaving the fee context completely unaffected on nodes that never needed the intervention in the first place.

## Changed Files

- `x/globalfee/ante/fee.go` — one-character guard added to the bypass zero-fee condition