### PR TITLE
fix(jwk): apply ValidateJWKKeySize and kty/alg consistency check in GenesisState.Validate

### DIFF
--- a/x/jwk/types/genesis.go
+++ b/x/jwk/types/genesis.go
@@ -65,6 +65,14 @@ func (gs GenesisState) Validate() error {
 			case jwa.HS256, jwa.HS384, jwa.HS512, jwa.NoSignature:
 				return errorsmod.Wrapf(ErrInvalidJWK, "invalid algorithm %s in genesis JWK for audience %s", sigAlg.String(), elem.Aud)
 			}
+
+			if err := ValidateJWKKeySize(parsedKey); err != nil {
+				return errorsmod.Wrapf(ErrInvalidJWK, "invalid key material in genesis JWK for audience %s: %s", elem.Aud, err)
+			}
+
+			if err := validateJWKKeyTypeAlgConsistency(parsedKey, sigAlg); err != nil {
+				return errorsmod.Wrapf(ErrInvalidJWK, "key type/algorithm mismatch in genesis JWK for audience %s: %s", elem.Aud, err)
+			}
 		}
 	}
 	// this line is used by starport scaffolding # genesis/types/validate

--- a/x/jwk/types/genesis_test.go
+++ b/x/jwk/types/genesis_test.go
@@ -158,6 +158,36 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			desc: "RSA private key in genesis is rejected",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "privkey-audience",
+						Admin: adminAddr,
+						// Minimal RSA-2048 private key JWK (RFC 7517 §C.2 test vector)
+						Key: `{"kty":"RSA","alg":"RS256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy1XEIAwyBLlypnARQj9PJWQ","p":"83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs","q":"3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelIU","dp":"G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emRAse6Gha0U7U_6c8WKrPa5kC3oXl2C7B8Vx2SVKGF-3CYC7U0_bvhK8hWq2NMDW5Ww","dq":"s9lAH9fggBsoFR33509CCVY1hc_2kflF8KHCzwF4YjEm0-4T5UNuFKlsYUkQdQg1QX2Rz2nBHiWPK7T6Ks_YQ","qi":"GyM_p6JrXySiz1toFgKbWV-JdI3jT4s9TwMvhLVQhP6z7PK1Y7iIw3RvGQWFfvhqYbYHCMN4TNHF8vxSBrY"}`,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "kty/alg mismatch in genesis is rejected",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				AudienceList: []types.Audience{
+					{
+						Aud:   "mismatch-audience",
+						Admin: adminAddr,
+						// RSA public key with EC algorithm — kty=RSA but alg=ES256
+						Key: `{"kty":"RSA","alg":"ES256","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}`,
+					},
+				},
+			},
+			valid: false,
+		},
 		// this line is used by starport scaffolding # types/genesis/testcase
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- `GenesisState.Validate` now calls `ValidateJWKKeySize(parsedKey)` to reject RSA keys > 4096 bits and any private key material stored on-chain
- Also calls `validateJWKKeyTypeAlgConsistency(parsedKey, sigAlg)` to reject kty/alg mismatches (e.g. `kty=RSA` with `alg=ES256`)
- Adds two new test cases to `genesis_test.go` covering both rejection paths

Fixes Copilot review comment on `release/v29`: `MsgCreateAudience`/`MsgUpdateAudience` both enforce these checks but `GenesisState.Validate` did not, allowing a genesis file that passes validation to result in unusable audiences post-startup.

## Test plan

- [ ] `TestGenesisState_Validate` — existing cases pass, new "RSA private key rejected" and "kty/alg mismatch rejected" cases pass
- [ ] No regression in `x/jwk/` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)