### PR TITLE
chore: upgrade barretenberg-go to v0.2.0

### DIFF
--- a/.goreleaser/build.yaml
+++ b/.goreleaser/build.yaml
@@ -30,9 +30,7 @@ builds:
     hooks:
       pre:
         - cmd: mkdir -p {{ .Env.LIB_PATH }}
-        # Download pre-built libbarretenberg.a from barretenberg-go releases.
-        # Version is read from go.mod, same pattern as wasmvm below.
-        - cmd: sh -c 'grep "github.com/burnt-labs/barretenberg-go" go.mod | cut -d " " -f 2 | xargs -I {} wget https://github.com/burnt-labs/barretenberg-go/releases/download/{}/{{ .Env.BB_LIB }} -O {{ .Env.LIB_PATH }}/libbarretenberg.a'
+        # barretenberg-go v0.2.0+ includes lib/ directory in the module, so no download needed.
         # Download pre-built libwasmvm from CosmWasm releases.
         - cmd: sh -c '[ "{{ .Os }}" = "windows" ] || grep "github.com/CosmWasm/wasmvm" go.mod | cut -d " " -f 1 | xargs -I {} go list -m {} | cut -d " " -f 2 | xargs -I {} wget https://github.com/CosmWasm/wasmvm/releases/download/{}/{{ .Env.WASM_LIB }} -O {{ .Env.LIB_PATH }}/{{ .Env.WASM_LIB}}'
         - cmd: echo Starting build...
@@ -66,7 +64,6 @@ builds:
       - CGO_ENABLED=1
       - CGO_LDFLAGS='-L./dist/lib'
       - LIB_PATH=./dist/lib
-      - BB_LIB=libbarretenberg_{{ .Os }}_{{ .Arch }}.a
       - >-
         {{- if eq .Os "darwin" }}MACOSX_DEPLOYMENT_TARGET=10.12{{- end }}
       - >-

--- a/e2e_tests/go.mod
+++ b/e2e_tests/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/btcsuite/btcd v0.25.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
-	github.com/burnt-labs/barretenberg-go v0.1.3 // indirect
+	github.com/burnt-labs/barretenberg-go v0.2.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect

--- a/e2e_tests/go.sum
+++ b/e2e_tests/go.sum
@@ -218,8 +218,8 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/burnt-labs/abstract-account v0.1.4 h1:se7N7U6ozGgU8sPqoXO42+E2Nacjt+0+cqmwAVjJyNg=
 github.com/burnt-labs/abstract-account v0.1.4/go.mod h1:2V5yhfxfCeIv4E0q6agH/spIpmGiv1DPTUHQ5RK153c=
-github.com/burnt-labs/barretenberg-go v0.1.3 h1:Gh1u5P33Ld/hw7X156B34kjtD/l5mFQVhhOOBbCYesQ=
-github.com/burnt-labs/barretenberg-go v0.1.3/go.mod h1:2SJlaxo5WVRzoaT+Di/VlSmIzrvPriLklpXqZXvSusI=
+github.com/burnt-labs/barretenberg-go v0.2.0 h1:WW7apaMkcYRMQOU4qNkKkeCMj4jlL28hdRsBBoCffvY=
+github.com/burnt-labs/barretenberg-go v0.2.0/go.mod h1:2SJlaxo5WVRzoaT+Di/VlSmIzrvPriLklpXqZXvSusI=
 github.com/burnt-labs/ibc-go/modules/light-clients/08-wasm/v10 v10.5.0-xion.1 h1:1ibq/o5Yj/uFRRtsYgB+PK2qespl7MQcekb5w+YjDnE=
 github.com/burnt-labs/ibc-go/modules/light-clients/08-wasm/v10 v10.5.0-xion.1/go.mod h1:fj/tKdN9BF5cSDHczss0elfJO26WuSMQaMyupsllzR8=
 github.com/burnt-labs/tokenfactory v0.53.4-xion.2 h1:c55X9mQSPj7WfVDixPBBRZDmsyOOT9uXvMBimvotDzw=

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/CosmWasm/wasmvm/v3 v3.0.3
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/burnt-labs/abstract-account v0.1.4
-	github.com/burnt-labs/barretenberg-go v0.1.3
+	github.com/burnt-labs/barretenberg-go v0.2.0
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.3
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/burnt-labs/abstract-account v0.1.4 h1:se7N7U6ozGgU8sPqoXO42+E2Nacjt+0+cqmwAVjJyNg=
 github.com/burnt-labs/abstract-account v0.1.4/go.mod h1:2V5yhfxfCeIv4E0q6agH/spIpmGiv1DPTUHQ5RK153c=
-github.com/burnt-labs/barretenberg-go v0.1.3 h1:Gh1u5P33Ld/hw7X156B34kjtD/l5mFQVhhOOBbCYesQ=
-github.com/burnt-labs/barretenberg-go v0.1.3/go.mod h1:2SJlaxo5WVRzoaT+Di/VlSmIzrvPriLklpXqZXvSusI=
+github.com/burnt-labs/barretenberg-go v0.2.0 h1:WW7apaMkcYRMQOU4qNkKkeCMj4jlL28hdRsBBoCffvY=
+github.com/burnt-labs/barretenberg-go v0.2.0/go.mod h1:2SJlaxo5WVRzoaT+Di/VlSmIzrvPriLklpXqZXvSusI=
 github.com/burnt-labs/ibc-go/modules/light-clients/08-wasm/v10 v10.5.0-xion.1 h1:1ibq/o5Yj/uFRRtsYgB+PK2qespl7MQcekb5w+YjDnE=
 github.com/burnt-labs/ibc-go/modules/light-clients/08-wasm/v10 v10.5.0-xion.1/go.mod h1:fj/tKdN9BF5cSDHczss0elfJO26WuSMQaMyupsllzR8=
 github.com/burnt-labs/tokenfactory v0.53.4-xion.2 h1:c55X9mQSPj7WfVDixPBBRZDmsyOOT9uXvMBimvotDzw=


### PR DESCRIPTION
Upgrades barretenberg-go from v0.1.3 to v0.2.0 for release/v29.

## Changes
- barretenberg-go v0.2.0 now includes prebuilt lib/ directory for all platforms
- Removed unnecessary artifact download hook from goreleaser
- Updated go.mod and e2e_tests/go.mod to use v0.2.0
- Simplified build process - no runtime artifact downloads needed

## Benefits
- Faster, more reproducible builds
- No external network dependency during build
- Library files included in Go module cache