### PR TITLE
fix(dkim): enforce static 1024-bit RSA minimum, remove MinRsaKeyBits governance param

### DIFF
--- a/x/dkim/types/msgs.go
+++ b/x/dkim/types/msgs.go
@@ -174,7 +174,7 @@ func ValidateDkimPubKeys(dkimKeys []DkimPubKey, params Params) error {
 
 // ValidateDkimPubKeysWithRevocation validates DKIM keys and optionally checks a revocation lookup.
 // isRevoked should return true if the provided pubkey has been revoked.
-// When enforceMinKeySize is true, additional size validation is applied
+// When enforceMinKeySize is true, keys below MinRSAKeyBits (1024) are rejected
 // (use for message validation). Genesis/state-loading paths should pass false
 // to allow legacy keys such as Yahoo's s1024 selector.
 func ValidateDkimPubKeysWithRevocation(
@@ -197,6 +197,10 @@ func ValidateDkimPubKeysWithRevocation(
 		rsaPubKey, err := ParseRSAPublicKey(pubKeyBytes)
 		if err != nil {
 			return err
+		}
+
+		if enforceMinKeySize && rsaPubKey.N.BitLen() < MinRSAKeyBits {
+			return errors.Wrapf(ErrInvalidPubKey, "RSA key size %d bits is below minimum %d bits", rsaPubKey.N.BitLen(), MinRSAKeyBits)
 		}
 
 		if isRevoked != nil {

--- a/x/dkim/types/msgs.go
+++ b/x/dkim/types/msgs.go
@@ -174,7 +174,7 @@ func ValidateDkimPubKeys(dkimKeys []DkimPubKey, params Params) error {
 
 // ValidateDkimPubKeysWithRevocation validates DKIM keys and optionally checks a revocation lookup.
 // isRevoked should return true if the provided pubkey has been revoked.
-// When enforceMinKeySize is true, keys below MinRSAKeyBits (1024) are rejected
+// When enforceMinKeySize is true, keys below DefaultMinRSAKeyBits (1024) are rejected
 // (use for message validation). Genesis/state-loading paths should pass false
 // to allow legacy keys such as Yahoo's s1024 selector.
 func ValidateDkimPubKeysWithRevocation(
@@ -199,8 +199,8 @@ func ValidateDkimPubKeysWithRevocation(
 			return err
 		}
 
-		if enforceMinKeySize && rsaPubKey.N.BitLen() < MinRSAKeyBits {
-			return errors.Wrapf(ErrInvalidPubKey, "RSA key size %d bits is below minimum %d bits", rsaPubKey.N.BitLen(), MinRSAKeyBits)
+		if enforceMinKeySize && rsaPubKey.N.BitLen() < DefaultMinRSAKeyBits {
+			return errors.Wrapf(ErrInvalidPubKey, "RSA key size %d bits is below minimum %d bits", rsaPubKey.N.BitLen(), DefaultMinRSAKeyBits)
 		}
 
 		if isRevoked != nil {

--- a/x/dkim/types/msgs_test.go
+++ b/x/dkim/types/msgs_test.go
@@ -433,7 +433,7 @@ func TestValidateDkimPubKeysWithRevocation(t *testing.T) {
 	})
 
 	t.Run("1024-bit key accepted for message path (Yahoo s1024 compatibility)", func(t *testing.T) {
-		// MinRSAKeyBits is set to 1024 to support legacy providers like Yahoo (s1024 selector).
+		// DefaultMinRSAKeyBits is set to 1024 to support legacy providers like Yahoo (s1024 selector).
 		// 1024-bit keys are low-assurance and expected to be rotated when providers upgrade.
 		smallKey, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: intentionally testing legacy 1024-bit key
 		require.NoError(t, err)

--- a/x/dkim/types/msgs_test.go
+++ b/x/dkim/types/msgs_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -447,6 +448,46 @@ func TestValidateDkimPubKeysWithRevocation(t *testing.T) {
 			KeyType:  types.KeyType_KEY_TYPE_RSA_UNSPECIFIED,
 		}
 		err = types.ValidateDkimPubKeysWithRevocation(context.Background(), []types.DkimPubKey{key}, params, nil, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("sub-1024-bit key rejected on message path", func(t *testing.T) {
+		// Go 1.24+ rejects rsa.GenerateKey for <1024-bit keys, so construct directly.
+		// A 512-bit modulus (64 bytes, high bit set) produces N.BitLen() == 512.
+		n := new(big.Int).SetBit(new(big.Int), 511, 1) // minimal 512-bit odd number
+		n.SetBit(n, 0, 1)
+		weakPub := &rsa.PublicKey{N: n, E: 65537}
+		pkixBytes, err := x509.MarshalPKIXPublicKey(weakPub)
+		require.NoError(t, err)
+		b64 := base64.StdEncoding.EncodeToString(pkixBytes)
+		key := types.DkimPubKey{
+			Domain:   "example.com",
+			Selector: "weak",
+			PubKey:   b64,
+			Version:  types.Version_VERSION_DKIM1_UNSPECIFIED,
+			KeyType:  types.KeyType_KEY_TYPE_RSA_UNSPECIFIED,
+		}
+		err = types.ValidateDkimPubKeysWithRevocation(context.Background(), []types.DkimPubKey{key}, params, nil, true)
+		require.Error(t, err)
+		require.ErrorIs(t, err, types.ErrInvalidPubKey)
+	})
+
+	t.Run("sub-1024-bit key accepted on genesis path (enforceMinKeySize false)", func(t *testing.T) {
+		// Construct a 512-bit RSA public key directly — rsa.GenerateKey refuses <1024 bits in Go 1.24+.
+		n := new(big.Int).SetBit(new(big.Int), 511, 1)
+		n.SetBit(n, 0, 1)
+		weakPub := &rsa.PublicKey{N: n, E: 65537}
+		pkixBytes, err := x509.MarshalPKIXPublicKey(weakPub)
+		require.NoError(t, err)
+		b64 := base64.StdEncoding.EncodeToString(pkixBytes)
+		key := types.DkimPubKey{
+			Domain:   "example.com",
+			Selector: "weak",
+			PubKey:   b64,
+			Version:  types.Version_VERSION_DKIM1_UNSPECIFIED,
+			KeyType:  types.KeyType_KEY_TYPE_RSA_UNSPECIFIED,
+		}
+		err = types.ValidateDkimPubKeysWithRevocation(context.Background(), []types.DkimPubKey{key}, params, nil, false)
 		require.NoError(t, err)
 	})
 }

--- a/x/dkim/types/params.go
+++ b/x/dkim/types/params.go
@@ -9,6 +9,11 @@ import (
 const (
 	DefaultMaxPubKeySizeBytes uint64 = 512
 
+	// MinRSAKeyBits is the minimum RSA key size accepted on the message path.
+	// 1024 bits is the floor to support the Yahoo s1024 selector; sub-1024-bit
+	// keys are cryptographically weak and always rejected.
+	MinRSAKeyBits int = 1024
+
 	// ValidateBasicMaxPubKeySizeBytes is a higher ceiling for ValidateBasic
 	// to allow on-chain params to be meaningful. The message server will
 	// enforce the actual param limits.

--- a/x/dkim/types/params.go
+++ b/x/dkim/types/params.go
@@ -9,10 +9,10 @@ import (
 const (
 	DefaultMaxPubKeySizeBytes uint64 = 512
 
-	// MinRSAKeyBits is the minimum RSA key size accepted on the message path.
+	// DefaultMinRSAKeyBits is the default minimum RSA key size accepted on the message path.
 	// 1024 bits is the floor to support the Yahoo s1024 selector; sub-1024-bit
 	// keys are cryptographically weak and always rejected.
-	MinRSAKeyBits int = 1024
+	DefaultMinRSAKeyBits int = 1024
 
 	// ValidateBasicMaxPubKeySizeBytes is a higher ceiling for ValidateBasic
 	// to allow on-chain params to be meaningful. The message server will


### PR DESCRIPTION
This pull request strengthens DKIM RSA public key validation by enforcing a minimum key size of 1024 bits for message validation, while allowing legacy keys for genesis or state-loading scenarios. It also adds comprehensive tests to ensure the correct enforcement of these rules.

**Key changes:**

Validation logic improvements:
* Enforced a minimum RSA key size of 1024 bits in the `ValidateDkimPubKeysWithRevocation` function for message validation paths, rejecting weaker keys as cryptographically unsafe. (`x/dkim/types/msgs.go`, [[1]](diffhunk://#diff-1eb2d8495a411eb7d105ba57af78127e2164ad0e3fc76c9dd53fcaff2a945c9fL177-R177) [[2]](diffhunk://#diff-1eb2d8495a411eb7d105ba57af78127e2164ad0e3fc76c9dd53fcaff2a945c9fR202-R205)
* Introduced the `MinRSAKeyBits` constant to define the minimum allowed RSA key size, with documentation clarifying its purpose and exceptions for legacy keys. (`x/dkim/types/params.go`, [x/dkim/types/params.goR12-R16](diffhunk://#diff-60f3a3045e0559b57448ebadb0739c3b98d934d0b0bd3cd28386cd3d5b4f89e9R12-R16))

Testing enhancements:
* Added tests to verify that sub-1024-bit RSA keys are rejected when minimum key size enforcement is enabled, and accepted when it is disabled (e.g., during genesis). These tests construct weak keys directly to bypass Go's stricter key generation. (`x/dkim/types/msgs_test.go`, [[1]](diffhunk://#diff-61d9bc4ff9a7b4f86a69ff25c0a94ee7c54704b150851529b08c5238b8d8f466R11) [[2]](diffhunk://#diff-61d9bc4ff9a7b4f86a69ff25c0a94ee7c54704b150851529b08c5238b8d8f466R453-R492)