### PR TITLE
fix(v29): cleanup stale code and testnet leaked-key audience

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 
 	storetypes "cosmossdk.io/store/types"
@@ -96,6 +97,17 @@ func (app *WasmApp) NextUpgradeHandler(ctx context.Context, plan upgradetypes.Pl
 	// 	<module>Genesis := <module>types.DefaultGenesisState()
 	// 	app.<module>Keeper.InitGenesis(sdkCtx, <module>Genesis)
 	// }
+
+	// Remove testnet audience that contains leaked RSA private key material.
+	// This audience would fail the stricter ValidateGenesis checks added in v29,
+	// blocking any future genesis export/import cycle on testnet-2.
+	const leakedAud = "poc-leaked-private-key"
+	if _, found := app.JwkKeeper.GetAudience(sdkCtx, leakedAud); found {
+		app.JwkKeeper.RemoveAudience(sdkCtx, leakedAud)
+		audHash := sha256.Sum256([]byte(leakedAud))
+		app.JwkKeeper.RemoveAudienceClaim(sdkCtx, audHash[:])
+		sdkCtx.Logger().Info("removed audience with leaked private key material", "aud", leakedAud)
+	}
 
 	// Run the migrations for all modules
 	migrations, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)

--- a/x/jwk/keeper/query_validate_jwt.go
+++ b/x/jwk/keeper/query_validate_jwt.go
@@ -74,10 +74,8 @@ func (k Keeper) ValidateJWT(goCtx context.Context, req *types.QueryValidateJWTRe
 	//    predicate to ensure exact parity.
 	//
 	// 2. jwt.Settings(jwt.WithCompactOnly(true)) (backstop): the global setting
-	//    is safe here because ValidateJWT is the only jwt.Parse() call site in
-	//    this binary. It uses atomic operations so concurrent calls are fine.
-	//    This guards against future code paths that might call jwt.Parse()
-	//    without the byte check above.
+	//    applies to all jwt.Parse() call sites (ValidateJWT and DecodeJWT).
+	//    It uses atomic operations so concurrent calls are fine.
 	jwt.Settings(jwt.WithCompactOnly(true))
 
 	trimmed := strings.TrimLeftFunc(req.SigBytes, unicode.IsSpace)

--- a/x/zk/keeper/query_server.go
+++ b/x/zk/keeper/query_server.go
@@ -115,11 +115,6 @@ func (q Querier) ProofVerify(c context.Context, req *types.QueryVerifyRequest) (
 	return &types.ProofVerifyResponse{Verified: verified}, nil
 }
 
-// bn254ScalarFieldPrime is the BN254 scalar field modulus r.
-// All Groth16 public inputs must be strictly less than this value.
-var bn254ScalarFieldPrime, _ = new(big.Int).SetString(
-	"21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
-
 // validatePublicInputsInScalarField rejects any public input string whose numeric
 // value is >= the BN254 scalar field prime.  Inputs may be decimal or 0x-prefixed hex,
 // matching the formats accepted by circom2gnark's ConvertPublicInputs.
@@ -132,7 +127,7 @@ func validatePublicInputsInScalarField(inputs []string) error {
 			base = 16
 		}
 		v, ok := new(big.Int).SetString(s, base)
-		if !ok || v.Sign() < 0 || v.Cmp(bn254ScalarFieldPrime) >= 0 {
+		if !ok || v.Sign() < 0 || v.Cmp(bn254ScalarPrime) >= 0 {
 			return errors.Wrapf(types.ErrInvalidRequest,
 				"public input[%d] is not a canonical BN254 scalar field element", i)
 		}

--- a/x/zk/types/params.go
+++ b/x/zk/types/params.go
@@ -37,11 +37,6 @@ const (
 	// Public inputs are provided as raw bytes (concatenated 32-byte big-endian field elements).
 	DefaultMaxGnarkPublicInputSizeBytes uint64 = 10 * 1024 // 10 KiB
 
-	// ProofVerifyGas is the flat gas cost charged per BN254 proof verification.
-	// BN254 pairing checks are computationally expensive; this cost bounds the
-	// number of verifications an account can submit per block under its gas limit.
-	ProofVerifyGas uint64 = 500_000
-
 	// MinProofOrInputSizeBytes is the minimum value governance may set for any
 	// proof or public-input size parameter (must be at least 1 byte).
 	MinProofOrInputSizeBytes uint64 = 1


### PR DESCRIPTION
## Summary
- **Testnet cleanup**: Remove `poc-leaked-private-key` audience in v29 upgrade handler — this audience contains leaked RSA private key material and would fail the stricter `ValidateGenesis` checks added in v29, blocking any future genesis export/import on testnet-2
- **Stale comment fix**: Update comment in `ValidateJWT` that incorrectly claimed it was the only `jwt.Parse()` call site (`DecodeJWT` also calls it)
- **Deduplicate BN254 prime**: Remove duplicate `bn254ScalarFieldPrime` constant in `query_server.go`, reuse `bn254ScalarPrime` from `keeper.go`
- **Remove dead constant**: Delete unused `ProofVerifyGas` constant from `params.go`

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Existing unit tests pass (`make test`)
- [ ] Verify upgrade handler runs cleanly on testnet-2 (audience removal is conditional — no-op on mainnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)