### PR TITLE
fix(zk): add panic recovery to VerifyGnark

### DIFF
--- a/x/zk/keeper/keeper.go
+++ b/x/zk/keeper/keeper.go
@@ -268,35 +268,56 @@ func (k *Keeper) Verify(ctx context.Context, proof *parser.CircomProof, vkey *pa
 // The public inputs must be serialized using gnark's witness.MarshalBinary() on the public part
 // of the witness (obtained via witness.Public()).
 func (k *Keeper) VerifyGnark(ctx context.Context, proofBytes []byte, vkeyBytes []byte, publicInputsBytes []byte) (bool, error) {
-	// Deserialize verification key
-	vk := groth16.NewVerifyingKey(ecc.BN254)
-	if _, err := vk.ReadFrom(bytes.NewReader(vkeyBytes)); err != nil {
-		return false, errors.Wrapf(types.ErrInvalidVKey, "failed to parse gnark vkey: %v", err)
-	}
+	// Wrap gnark calls with panic recovery — gnark may panic on malformed
+	// proofs, vkeys, or witnesses that pass initial parsing but hit invalid
+	// curve points during deserialization or pairing. Since ProofVerifyGnark
+	// is Stargate-whitelisted, any CosmWasm contract can reach this code path.
+	var (
+		verified  bool
+		verifyErr error
+	)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				k.logger.Error("panic during gnark groth16 verification", "panic", r)
+				verifyErr = errors.Wrap(types.ErrInvalidRequest, "internal error during proof verification")
+			}
+		}()
 
-	// Deserialize proof
-	proof := groth16.NewProof(ecc.BN254)
-	if _, err := proof.ReadFrom(bytes.NewReader(proofBytes)); err != nil {
-		return false, errors.Wrapf(types.ErrInvalidRequest, "failed to parse gnark proof: %v", err)
-	}
+		// Deserialize verification key
+		vk := groth16.NewVerifyingKey(ecc.BN254)
+		if _, err := vk.ReadFrom(bytes.NewReader(vkeyBytes)); err != nil {
+			verifyErr = errors.Wrapf(types.ErrInvalidVKey, "failed to parse gnark vkey: %v", err)
+			return
+		}
 
-	// Create and unmarshal public witness
-	publicWitness, err := witness.New(ecc.BN254.ScalarField())
-	if err != nil {
-		return false, errors.Wrapf(types.ErrInvalidRequest, "failed to create witness: %v", err)
-	}
+		// Deserialize proof
+		proof := groth16.NewProof(ecc.BN254)
+		if _, err := proof.ReadFrom(bytes.NewReader(proofBytes)); err != nil {
+			verifyErr = errors.Wrapf(types.ErrInvalidRequest, "failed to parse gnark proof: %v", err)
+			return
+		}
 
-	if err := publicWitness.UnmarshalBinary(publicInputsBytes); err != nil {
-		return false, errors.Wrapf(types.ErrInvalidRequest, "failed to unmarshal public inputs: %v", err)
-	}
+		// Create and unmarshal public witness
+		publicWitness, err := witness.New(ecc.BN254.ScalarField())
+		if err != nil {
+			verifyErr = errors.Wrapf(types.ErrInvalidRequest, "failed to create witness: %v", err)
+			return
+		}
 
-	// Verify the proof
-	if err := groth16.Verify(proof, vk, publicWitness); err != nil {
-		// Verification failed - this is not an error, just means the proof is invalid
-		return false, nil
-	}
+		if err := publicWitness.UnmarshalBinary(publicInputsBytes); err != nil {
+			verifyErr = errors.Wrapf(types.ErrInvalidRequest, "failed to unmarshal public inputs: %v", err)
+			return
+		}
 
-	return true, nil
+		// Verify the proof
+		if err := groth16.Verify(proof, vk, publicWitness); err != nil {
+			// Verification failed - not an error, just means the proof is invalid
+			return
+		}
+		verified = true
+	}()
+	return verified, verifyErr
 }
 
 // AddVKey adds a new verification key to the store.


### PR DESCRIPTION
## Summary
- **C1 (Critical)**: `VerifyGnark` (gnark native Groth16 BN254) lacked panic recovery, unlike `Verify` (circom Groth16) and `ProofVerifyUltraHonk`. Since `ProofVerifyGnark` is Stargate-whitelisted, any CosmWasm contract can reach this code path — a panic in gnark deserialization or pairing would halt the chain.
- **M3 (Resolved)**: Confirmed gnark's `witness.UnmarshalBinary()` already rejects non-canonical BN254 field elements via `smallerThanModulus()` in gnark-crypto's `BigEndian.Element()`. No additional scalar field validation needed (unlike the circom path which required explicit checks due to circom2gnark's silent modular reduction).

## Changes
- Wrap all gnark deserialization and verification calls in `VerifyGnark()` with `defer func() { recover() }()`, matching the existing pattern in `Verify()` at keeper.go:246-260

## Test plan
- [x] `go build ./x/zk/...` passes
- [x] `go vet ./x/zk/...` passes
- [x] `go test ./x/zk/... -count=1` — all 6 packages pass
- [ ] E2E: `make test-zk-all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)