### PR TITLE
fix(ci): extract linux binaries from Docker images

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -35,17 +35,19 @@ jobs:
     uses: ./.github/workflows/binaries-darwin.yaml
     secrets: inherit
 
-  build-linux:
-    name: Build Linux Binaries
-    uses: ./.github/workflows/binaries-linux.yaml
-    secrets: inherit
-
+  # Linux binaries are extracted from natively-built Docker images instead of
+  # cross-compiled via goreleaser-cross. This avoids libc++/libstdc++ link
+  # errors with barretenberg-go's arm64 static library.
   build-docker:
     name: Build Docker Images
-    needs:
-      - build-darwin
-      - build-linux
     uses: ./.github/workflows/docker-build.yaml
+    secrets: inherit
+
+  extract-linux-binaries:
+    name: Extract Linux Binaries
+    needs:
+      - build-docker
+    uses: ./.github/workflows/extract-binaries-linux.yaml
     secrets: inherit
 
   push-docker:
@@ -75,6 +77,8 @@ jobs:
       - lint
       - update-swagger
       - unit-tests
+      - build-darwin
+      - extract-linux-binaries
       - push-docker
       - docker-scout
       - e2e-tests

--- a/.github/workflows/extract-binaries-linux.yaml
+++ b/.github/workflows/extract-binaries-linux.yaml
@@ -1,0 +1,62 @@
+name: Extract Linux Binaries from Docker Images
+
+# reusable workflow, do not add triggers
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  extract-binaries:
+    name: Extract xiond-${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'depot-ubuntu-24.04-arm' || 'depot-ubuntu-24.04' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - linux
+        arch:
+          - amd64
+          - arm64
+
+    steps:
+      - name: Download Docker image tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-${{ matrix.os }}-${{ matrix.arch }}.tar
+          path: ${{ runner.temp }}
+
+      - name: Load Docker image
+        run: docker load < ${{ runner.temp }}/docker-${{ matrix.os }}-${{ matrix.arch }}.tar
+
+      - name: Extract xiond binary from image
+        run: |
+          set -euo pipefail
+
+          # Determine the variant suffix goreleaser expects
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            VARIANT="v8.0"
+          else
+            VARIANT="v1"
+          fi
+
+          # Create the directory structure expected by exec-goreleaser / release.yaml
+          DEST="dist/xiond_${{ matrix.os }}_${{ matrix.arch }}_${VARIANT}/bin"
+          mkdir -p "${DEST}"
+
+          # Copy the binary out of the Docker image
+          CONTAINER=$(docker create "xion:${{ matrix.os }}-${{ matrix.arch }}")
+          docker cp "${CONTAINER}:/usr/bin/xiond" "${DEST}/xiond-${{ matrix.os }}-${{ matrix.arch }}"
+          docker rm "${CONTAINER}"
+
+          # Verify the binary
+          file "${DEST}/xiond-${{ matrix.os }}-${{ matrix.arch }}"
+          chmod +x "${DEST}/xiond-${{ matrix.os }}-${{ matrix.arch }}"
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: xiond-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/**/xiond-${{ matrix.os }}-${{ matrix.arch }}
+          retention-days: 3
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

- Replaces cross-compiled Linux binary builds with extraction from natively-built Docker images
- Fixes the arm64 linker failure caused by barretenberg-go's libc++ static lib vs goreleaser-cross's libstdc++
- Adds `extract-binaries-linux.yaml` reusable workflow that loads Docker tarballs and copies `/usr/bin/xiond` out
- Reorders `create-release.yaml`: Docker images build first (no pre-built binary dependency), then linux binaries are extracted from them
- Darwin builds are completely unchanged
- `binaries-linux.yaml` left in place but no longer called from the release pipeline

## Pipeline flow (before → after)

**Before:**
```
build-linux + build-darwin → build-docker → push/e2e/scout → goreleaser
```

**After:**
```
build-docker → extract-linux-binaries ─┐
build-darwin ──────────────────────────→├→ goreleaser
push/e2e/scout ────────────────────────┘
```

## Test plan

- [ ] Trigger `create-release.yaml` via `workflow_dispatch` on this branch
- [ ] Verify Docker images build without pre-built binaries (goreleaser fallback path)
- [ ] Verify `extract-binaries-linux.yaml` extracts binaries with correct directory structure
- [ ] Verify `exec-goreleaser` finds linux + darwin binaries at expected paths
- [ ] Verify Docker push, scout, and e2e jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)