### PR TITLE
fix(ci): robust artifact placement in goreleaser

### DIFF
--- a/.github/workflows/exec-goreleaser.yaml
+++ b/.github/workflows/exec-goreleaser.yaml
@@ -27,8 +27,28 @@ jobs:
 
       - name: Move artifacts
         run: |
+          echo "=== Downloaded artifact contents ==="
+          find ${{ runner.temp }} -name 'xiond-*' -type f
           mkdir -p dist
-          mv ${{ runner.temp }}/*/xiond* dist
+          # Place each binary into the directory structure goreleaser expects:
+          #   dist/xiond_<os>_<arch>_<variant>/bin/xiond-<os>-<arch>
+          for bin in $(find ${{ runner.temp }} -name 'xiond-*' -type f); do
+            filename=$(basename "$bin")
+            # Parse os and arch from filename (e.g. xiond-linux-amd64 → linux, amd64)
+            os=$(echo "$filename" | cut -d- -f2)
+            arch=$(echo "$filename" | cut -d- -f3)
+            case "$arch" in
+              arm64) variant="v8.0" ;;
+              amd64) variant="v1" ;;
+              *)     variant="" ;;
+            esac
+            dest="dist/xiond_${os}_${arch}_${variant}/bin"
+            mkdir -p "$dest"
+            cp "$bin" "$dest/$filename"
+            echo "Placed $filename → $dest/$filename"
+          done
+          echo "=== Final dist layout ==="
+          find dist -type f
 
       - name: Set Go Version
         run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Fixes the `exec-goreleaser.yaml` "Move artifacts" step which failed with `no such file or directory` after the extract-from-docker change (#561)
- The old `mv ${{ runner.temp }}/*/xiond* dist` glob relied on a specific directory hierarchy from upload-artifact that isn't guaranteed with `merge-multiple: true`
- New logic uses `find` to locate all `xiond-*` binaries, parses os/arch from filenames, and creates the exact directory structure goreleaser's `prebuilt` builder expects: `dist/xiond_<os>_<arch>_<variant>/bin/xiond-<os>-<arch>`
- Adds diagnostic output to help debug artifact issues

## Test plan

- [ ] Trigger `create-release.yaml` via `workflow_dispatch` on this branch
- [ ] Verify "Move artifacts" step shows correct file placement
- [ ] Verify goreleaser successfully imports all prebuilt binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)