### PR TITLE
feat: register v30 upgrade handler (UpgradeName v29 -> v30)

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 
 	storetypes "cosmossdk.io/store/types"
@@ -97,17 +96,6 @@ func (app *WasmApp) NextUpgradeHandler(ctx context.Context, plan upgradetypes.Pl
 	// 	<module>Genesis := <module>types.DefaultGenesisState()
 	// 	app.<module>Keeper.InitGenesis(sdkCtx, <module>Genesis)
 	// }
-
-	// Remove testnet audience that contains leaked RSA private key material.
-	// This audience would fail the stricter ValidateGenesis checks added in v29,
-	// blocking any future genesis export/import cycle on testnet-2.
-	const leakedAud = "poc-leaked-private-key"
-	if _, found := app.JwkKeeper.GetAudience(sdkCtx, leakedAud); found {
-		app.JwkKeeper.RemoveAudience(sdkCtx, leakedAud)
-		audHash := sha256.Sum256([]byte(leakedAud))
-		app.JwkKeeper.RemoveAudienceClaim(sdkCtx, audHash[:])
-		sdkCtx.Logger().Info("removed audience with leaked private key material", "aud", leakedAud)
-	}
 
 	// Run the migrations for all modules
 	migrations, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
-const UpgradeName = "v29"
+const UpgradeName = "v30"
 
 func (app *WasmApp) RegisterUpgradeHandlers() {
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()


### PR DESCRIPTION
Registers the v30 upgrade handler by bumping `UpgradeName` from `v29` to `v30` in `app/upgrades.go`, per Greg's direction.

`RegisterUpgradeHandlers()` reads this constant and wires `NextUpgradeHandler` + the store loader generically, so no other code change is needed to register the upgrade.

Also removes the v29-specific leaked-key audience cleanup from `NextUpgradeHandler` (completed v29 work) and its now-unused `crypto/sha256` import, leaving the handler to just run module migrations.