### PR TITLE
Release/v30

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 
 	storetypes "cosmossdk.io/store/types"
@@ -13,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
-const UpgradeName = "v29"
+const UpgradeName = "v30"
 
 func (app *WasmApp) RegisterUpgradeHandlers() {
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
@@ -97,17 +96,6 @@ func (app *WasmApp) NextUpgradeHandler(ctx context.Context, plan upgradetypes.Pl
 	// 	<module>Genesis := <module>types.DefaultGenesisState()
 	// 	app.<module>Keeper.InitGenesis(sdkCtx, <module>Genesis)
 	// }
-
-	// Remove testnet audience that contains leaked RSA private key material.
-	// This audience would fail the stricter ValidateGenesis checks added in v29,
-	// blocking any future genesis export/import cycle on testnet-2.
-	const leakedAud = "poc-leaked-private-key"
-	if _, found := app.JwkKeeper.GetAudience(sdkCtx, leakedAud); found {
-		app.JwkKeeper.RemoveAudience(sdkCtx, leakedAud)
-		audHash := sha256.Sum256([]byte(leakedAud))
-		app.JwkKeeper.RemoveAudienceClaim(sdkCtx, audHash[:])
-		sdkCtx.Logger().Info("removed audience with leaked private key material", "aud", leakedAud)
-	}
 
 	// Run the migrations for all modules
 	migrations, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)

--- a/client/docs/config.yaml
+++ b/client/docs/config.yaml
@@ -1,8 +1,8 @@
 swagger: "2.0"
 info:
-  title: XION - gRPC Gateway docs
-  description: A REST interface for state queries
-  version: v29.0.0
+  title: Verona - gRPC Gateway docs
+  description: A REST interface for Verona state queries
+  version: v30
 apis:
   - url: ./cosmos/auth/v1beta1/query.swagger.json
     operationIds:
@@ -202,25 +202,25 @@ apis:
         Params: GlobalFeeParams
     tags:
       rename:
-        Query: XionGlobalFee
+        Query: VeronaGlobalFee
   - url: ./xion/jwk/v1/query.swagger.json
     operationIds:
       rename:
         Params: JWKParams
     tags:
       rename:
-        Query: XionJWK
+        Query: VeronaJWK
   - url: ./xion/mint/v1/query.swagger.json
     operationIds:
       rename:
         Params: XionMintParams
     tags:
       rename:
-        Query: XionMint
+        Query: VeronaMint
   - url: ./xion/v1/query.swagger.json
     tags:
       rename:
-        Query: Xion
+        Query: Verona
   - url: ./cosmos/circuit/v1/query.swagger.json
     operationIds:
       rename:
@@ -243,7 +243,7 @@ apis:
         GranterGrants: XionGranterGrants
     tags:
       rename:
-        Query: XionIndexerAuthz
+        Query: VeronaIndexerAuthz
   - url: ./xion/indexer/feegrant/v1/query.swagger.json
     operationIds:
       rename:
@@ -252,7 +252,7 @@ apis:
         AllowancesByGranter: XionAllowancesByGranter
     tags:
       rename:
-        Query: XionIndexerFeegrant
+        Query: VeronaIndexerFeegrant
 
 # not included
 # ./cosmos/app/v1alpha1/query.swagger.json

--- a/client/docs/config.yaml
+++ b/client/docs/config.yaml
@@ -213,7 +213,7 @@ apis:
   - url: ./xion/mint/v1/query.swagger.json
     operationIds:
       rename:
-        Params: XionMintParams
+        Params: VeronaMintParams
     tags:
       rename:
         Query: VeronaMint
@@ -238,18 +238,18 @@ apis:
   - url: ./xion/indexer/authz/v1/query.swagger.json
     operationIds:
       rename:
-        Grants: XionGrants
-        GranteeGrants: XionGranteeGrants
-        GranterGrants: XionGranterGrants
+        Grants: VeronaGrants
+        GranteeGrants: VeronaGranteeGrants
+        GranterGrants: VeronaGranterGrants
     tags:
       rename:
         Query: VeronaIndexerAuthz
   - url: ./xion/indexer/feegrant/v1/query.swagger.json
     operationIds:
       rename:
-        Allowance: XionAllowance
-        Allowances: XionAllowances
-        AllowancesByGranter: XionAllowancesByGranter
+        Allowance: VeronaAllowance
+        Allowances: VeronaAllowances
+        AllowancesByGranter: VeronaAllowancesByGranter
     tags:
       rename:
         Query: VeronaIndexerFeegrant

--- a/client/docs/static/index.html
+++ b/client/docs/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>XION API</title>
+        <title>Verona API</title>
         <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css" />
         <link rel="icon" type="image/png" href="//unpkg.com/swagger-ui-dist@5.17.14/favicon-16x16.png" />
     </head>

--- a/client/docs/static/openapi.json
+++ b/client/docs/static/openapi.json
@@ -25920,7 +25920,7 @@
         "/xion/mint/v1/params": {
             "get": {
                 "summary": "Params returns the total set of minting parameters.",
-                "operationId": "XionMintParams",
+                "operationId": "VeronaMintParams",
                 "responses": {
                     "200": {
                         "description": "A successful response.",
@@ -26396,7 +26396,7 @@
         "/xion/indexer/authz/v1/grants": {
             "get": {
                 "summary": "Returns list of `Authorization`, granted to the grantee by the granter.",
-                "operationId": "XionGrants",
+                "operationId": "VeronaGrants",
                 "responses": {
                     "200": {
                         "description": "A successful response.",
@@ -26573,7 +26573,7 @@
             "get": {
                 "summary": "GranteeGrants returns a list of `GrantAuthorization` by grantee.",
                 "description": "Since: cosmos-sdk 0.46",
-                "operationId": "XionGranteeGrants",
+                "operationId": "VeronaGranteeGrants",
                 "responses": {
                     "200": {
                         "description": "A successful response.",
@@ -26737,7 +26737,7 @@
             "get": {
                 "summary": "GranterGrants returns list of `GrantAuthorization`, granted by granter.",
                 "description": "Since: cosmos-sdk 0.46",
-                "operationId": "XionGranterGrants",
+                "operationId": "VeronaGranterGrants",
                 "responses": {
                     "200": {
                         "description": "A successful response.",
@@ -26900,7 +26900,7 @@
         "/xion/indexer/feegrant/v1/allowance/{granter}/{grantee}": {
             "get": {
                 "summary": "Allowance returns granted allowance to the grantee by the granter.",
-                "operationId": "XionAllowance",
+                "operationId": "VeronaAllowance",
                 "responses": {
                     "200": {
                         "description": "A successful response.",
@@ -27003,7 +27003,7 @@
         "/xion/indexer/feegrant/v1/allowances/{grantee}": {
             "get": {
                 "summary": "Allowances returns all the grants for the given grantee address.",
-                "operationId": "XionAllowances",
+                "operationId": "VeronaAllowances",
                 "responses": {
                     "200": {
                         "description": "A successful response.",
@@ -27164,7 +27164,7 @@
         "/xion/indexer/feegrant/v1/issued/{granter}": {
             "get": {
                 "summary": "AllowancesByGranter returns all the grants given by an address",
-                "operationId": "XionAllowancesByGranter",
+                "operationId": "VeronaAllowancesByGranter",
                 "responses": {
                     "200": {
                         "description": "A successful response.",

--- a/client/docs/static/openapi.json
+++ b/client/docs/static/openapi.json
@@ -1,9 +1,9 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "title": "XION - gRPC Gateway docs",
-        "description": "A REST interface for state queries",
-        "version": "v29.0.0"
+        "title": "Verona - gRPC Gateway docs",
+        "description": "A REST interface for Verona state queries",
+        "version": "v30"
     },
     "paths": {
         "/cosmos/auth/v1beta1/account_info/{address}": {
@@ -25133,7 +25133,7 @@
                     }
                 },
                 "tags": [
-                    "XionGlobalFee"
+                    "VeronaGlobalFee"
                 ]
             }
         },
@@ -25277,7 +25277,7 @@
                     }
                 ],
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25361,7 +25361,7 @@
                     }
                 ],
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25438,7 +25438,7 @@
                     }
                 ],
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25540,7 +25540,7 @@
                     }
                 ],
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25611,7 +25611,7 @@
                     }
                 },
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25713,7 +25713,7 @@
                     }
                 ],
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25793,7 +25793,7 @@
                     }
                 ],
                 "tags": [
-                    "XionJWK"
+                    "VeronaJWK"
                 ]
             }
         },
@@ -25853,7 +25853,7 @@
                     }
                 },
                 "tags": [
-                    "XionMint"
+                    "VeronaMint"
                 ]
             }
         },
@@ -25913,7 +25913,7 @@
                     }
                 },
                 "tags": [
-                    "XionMint"
+                    "VeronaMint"
                 ]
             }
         },
@@ -25999,7 +25999,7 @@
                     }
                 },
                 "tags": [
-                    "XionMint"
+                    "VeronaMint"
                 ]
             }
         },
@@ -26565,7 +26565,7 @@
                     }
                 ],
                 "tags": [
-                    "XionIndexerAuthz"
+                    "VeronaIndexerAuthz"
                 ]
             }
         },
@@ -26729,7 +26729,7 @@
                     }
                 ],
                 "tags": [
-                    "XionIndexerAuthz"
+                    "VeronaIndexerAuthz"
                 ]
             }
         },
@@ -26893,7 +26893,7 @@
                     }
                 ],
                 "tags": [
-                    "XionIndexerAuthz"
+                    "VeronaIndexerAuthz"
                 ]
             }
         },
@@ -26996,7 +26996,7 @@
                     }
                 ],
                 "tags": [
-                    "XionIndexerFeegrant"
+                    "VeronaIndexerFeegrant"
                 ]
             }
         },
@@ -27157,7 +27157,7 @@
                     }
                 ],
                 "tags": [
-                    "XionIndexerFeegrant"
+                    "VeronaIndexerFeegrant"
                 ]
             }
         },
@@ -27318,7 +27318,7 @@
                     }
                 ],
                 "tags": [
-                    "XionIndexerFeegrant"
+                    "VeronaIndexerFeegrant"
                 ]
             }
         }

--- a/client/docs/static/swagger.json
+++ b/client/docs/static/swagger.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "XION - gRPC Gateway docs",
-    "description": "A REST interface for state queries",
-    "version": "v29.0.0"
+    "title": "Verona - gRPC Gateway docs",
+    "description": "A REST interface for Verona state queries",
+    "version": "v30"
   },
   "paths": {
     "/cosmos/auth/v1beta1/account_info/{address}": {
@@ -22743,7 +22743,7 @@
           }
         },
         "tags": [
-          "XionGlobalFee"
+          "VeronaGlobalFee"
         ]
       }
     },
@@ -22869,7 +22869,7 @@
           }
         ],
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -22943,7 +22943,7 @@
           }
         ],
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -23010,7 +23010,7 @@
           }
         ],
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -23098,7 +23098,7 @@
           }
         ],
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -23161,7 +23161,7 @@
           }
         },
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -23249,7 +23249,7 @@
           }
         ],
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -23317,7 +23317,7 @@
           }
         ],
         "tags": [
-          "XionJWK"
+          "VeronaJWK"
         ]
       }
     },
@@ -23369,7 +23369,7 @@
           }
         },
         "tags": [
-          "XionMint"
+          "VeronaMint"
         ]
       }
     },
@@ -23421,7 +23421,7 @@
           }
         },
         "tags": [
-          "XionMint"
+          "VeronaMint"
         ]
       }
     },
@@ -23499,7 +23499,7 @@
           }
         },
         "tags": [
-          "XionMint"
+          "VeronaMint"
         ]
       }
     },
@@ -23997,7 +23997,7 @@
           }
         ],
         "tags": [
-          "XionIndexerAuthz"
+          "VeronaIndexerAuthz"
         ]
       }
     },
@@ -24141,7 +24141,7 @@
           }
         ],
         "tags": [
-          "XionIndexerAuthz"
+          "VeronaIndexerAuthz"
         ]
       }
     },
@@ -24285,7 +24285,7 @@
           }
         ],
         "tags": [
-          "XionIndexerAuthz"
+          "VeronaIndexerAuthz"
         ]
       }
     },
@@ -24376,7 +24376,7 @@
           }
         ],
         "tags": [
-          "XionIndexerFeegrant"
+          "VeronaIndexerFeegrant"
         ]
       }
     },
@@ -24517,7 +24517,7 @@
           }
         ],
         "tags": [
-          "XionIndexerFeegrant"
+          "VeronaIndexerFeegrant"
         ]
       }
     },
@@ -24658,7 +24658,7 @@
           }
         ],
         "tags": [
-          "XionIndexerFeegrant"
+          "VeronaIndexerFeegrant"
         ]
       }
     }

--- a/client/docs/static/swagger.json
+++ b/client/docs/static/swagger.json
@@ -23428,7 +23428,7 @@
     "/xion/mint/v1/params": {
       "get": {
         "summary": "Params returns the total set of minting parameters.",
-        "operationId": "XionMintParams",
+        "operationId": "VeronaMintParams",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -23852,7 +23852,7 @@
     "/xion/indexer/authz/v1/grants": {
       "get": {
         "summary": "Returns list of `Authorization`, granted to the grantee by the granter.",
-        "operationId": "XionGrants",
+        "operationId": "VeronaGrants",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -24005,7 +24005,7 @@
       "get": {
         "summary": "GranteeGrants returns a list of `GrantAuthorization` by grantee.",
         "description": "Since: cosmos-sdk 0.46",
-        "operationId": "XionGranteeGrants",
+        "operationId": "VeronaGranteeGrants",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -24149,7 +24149,7 @@
       "get": {
         "summary": "GranterGrants returns list of `GrantAuthorization`, granted by granter.",
         "description": "Since: cosmos-sdk 0.46",
-        "operationId": "XionGranterGrants",
+        "operationId": "VeronaGranterGrants",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -24292,7 +24292,7 @@
     "/xion/indexer/feegrant/v1/allowance/{granter}/{grantee}": {
       "get": {
         "summary": "Allowance returns granted allowance to the grantee by the granter.",
-        "operationId": "XionAllowance",
+        "operationId": "VeronaAllowance",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -24383,7 +24383,7 @@
     "/xion/indexer/feegrant/v1/allowances/{grantee}": {
       "get": {
         "summary": "Allowances returns all the grants for the given grantee address.",
-        "operationId": "XionAllowances",
+        "operationId": "VeronaAllowances",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -24524,7 +24524,7 @@
     "/xion/indexer/feegrant/v1/issued/{granter}": {
       "get": {
         "summary": "AllowancesByGranter returns all the grants given by an address",
-        "operationId": "XionAllowancesByGranter",
+        "operationId": "VeronaAllowancesByGranter",
         "responses": {
           "200": {
             "description": "A successful response.",


### PR DESCRIPTION
This pull request updates the project to the new "Verona" release (v30), replacing all previous "Xion" references and version numbers throughout the codebase and documentation. It also removes legacy code related to a testnet audience with a leaked private key. The most significant changes are summarized below:

**Upgrade and Naming Updates:**

* Changed the upgrade name constant from `"v29"` to `"v30"` in `app/upgrades.go`, signaling the new release version.
* Updated all documentation, OpenAPI, and Swagger files to use "Verona" instead of "Xion" in titles, descriptions, tags, and version numbers. This includes `client/docs/config.yaml`,
`client/docs/static/index.html`, `client/docs/static/openapi.json`, and `client/docs/static/swagger.json`.
[[1]](diffhunk://#diff-f8c6defcc262f9da2d31c779a3bf423772af16800e312eb9f0ef4fb861688252L3-R5) [[2]](diffhunk://#diff-f8c6defcc262f9da2d31c779a3bf423772af16800e312eb9f0ef4fb861688252L205-R223) [[3]](diffhunk://#diff-f8c6defcc262f9da2d31c779a3bf423772af16800e312eb9f0ef4fb861688252L246-R246) [[4]](diffhunk://#diff-f8c6defcc262f9da2d31c779a3bf423772af16800e312eb9f0ef4fb861688252L255-R255) [[5]](diffhunk://#diff-53e9820ea0e4928dee56a650f4504fe0a75e6551382b1f7a22a14663e48b016cL5-R5) [[6]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL4-R6) [[7]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25136-R25136) [[8]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25280-R25280) [[9]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25364-R25364) [[10]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25441-R25441) [[11]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25543-R25543) [[12]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25614-R25614) [[13]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25716-R25716) [[14]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25796-R25796) [[15]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25856-R25856) [[16]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL25916-R25916) [[17]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL26002-R26002) [[18]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL26568-R26568) [[19]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL26732-R26732) [[20]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL26896-R26896) [[21]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL26999-R26999) [[22]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL27160-R27160) [[23]](diffhunk://#diff-386a246a0b4d1f3bb64a258ce2cb6f1f41a779c5d6d0b76d21a77dfc95d67fcaL27321-R27321) [[24]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL4-R6) [[25]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL22746-R22746) [[26]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL22872-R22872) [[27]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL22946-R22946) [[28]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23013-R23013) [[29]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23101-R23101) [[30]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23164-R23164) [[31]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23252-R23252) [[32]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23320-R23320) [[33]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23372-R23372) [[34]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23424-R23424) [[35]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL23502-R23502) [[36]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL24000-R24000) [[37]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL24144-R24144) [[38]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL24288-R24288) [[39]](diffhunk://#diff-29ed015c57a76af9d207430ce4bdb8a1a999afde18d1e069e7a03be7953dfcdaL24379-R24379)

**Code Cleanup:**

* Removed legacy code in `app/upgrades.go` that handled the deletion of a testnet audience with a leaked RSA private key, as this is no longer needed for v30.
* Removed the unnecessary `crypto/sha256` import from `app/upgrades.go` since the related code was deleted.

These changes ensure the codebase and documentation are consistent with the new "Verona" branding and remove outdated, testnet-specific logic.