### PR TITLE
fix: upgrade CometBFT and enforce validator timeout flag

### DIFF
--- a/cmd/xiond/root.go
+++ b/cmd/xiond/root.go
@@ -100,7 +100,16 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			customAppTemplate, customAppConfig := initAppConfig()
 			customTMConfig := initTendermintConfig()
 
-			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, customTMConfig)
+			if err := server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, customTMConfig); err != nil {
+				return err
+			}
+
+			timeoutCommit, err := cmd.Flags().GetDuration("consensus.timeout_commit")
+			if err != nil {
+				return err
+			}
+			setValidatorTimeout(server.GetServerContextFromCmd(cmd), timeoutCommit)
+			return nil
 		},
 	}
 
@@ -121,19 +130,12 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 // initTendermintConfig helps to override default Tendermint Config values.
 // return tmcfg.DefaultConfig if no custom configuration is required for the application.
 func initTendermintConfig() *tmcfg.Config {
-	cfg := tmcfg.DefaultConfig()
+	return tmcfg.DefaultConfig()
+}
 
-	// Check for consensus.timeout_commit flag
-	if viper.IsSet("consensus.timeout_commit") {
-		timeoutCommitStr := viper.GetString("consensus.timeout_commit")
-		if timeoutCommitStr != "" {
-			if timeoutCommit, err := time.ParseDuration(timeoutCommitStr); err == nil {
-				cfg.Consensus.TimeoutCommit = timeoutCommit
-			}
-		}
-	}
-
-	return cfg
+// setValidatorTimeout applies the CLI-only timeout after config.toml is loaded.
+func setValidatorTimeout(serverCtx *server.Context, timeoutCommit time.Duration) {
+	serverCtx.Config.Consensus.TimeoutCommit = timeoutCommit
 }
 
 // initAppConfig helps to override default appConfig template and configs.
@@ -174,9 +176,7 @@ func initRootCmd(rootCmd *cobra.Command,
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd) // nolint:staticcheck
 	wasm.AddModuleInitFlags(startCmd)
-
-	// Add consensus timeout_commit flag
-	startCmd.Flags().String("consensus.timeout_commit", "", "How long to wait after committing a block, before starting on the new height (e.g. 1s, 500ms)")
+	startCmd.Flags().Duration("consensus.timeout_commit", time.Second, "How long to wait after committing a block before starting the next height")
 }
 
 // genesisCommand builds genesis-related `simd genesis` command. Users may provide application specific commands as a parameter

--- a/cmd/xiond/root.go
+++ b/cmd/xiond/root.go
@@ -104,11 +104,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 				return err
 			}
 
-			timeoutCommit, err := cmd.Flags().GetDuration("consensus.timeout_commit")
-			if err != nil {
+			if err := applyValidatorTimeout(cmd); err != nil {
 				return err
 			}
-			setValidatorTimeout(server.GetServerContextFromCmd(cmd), timeoutCommit)
 			return nil
 		},
 	}
@@ -136,6 +134,23 @@ func initTendermintConfig() *tmcfg.Config {
 // setValidatorTimeout applies the CLI-only timeout after config.toml is loaded.
 func setValidatorTimeout(serverCtx *server.Context, timeoutCommit time.Duration) {
 	serverCtx.Config.Consensus.TimeoutCommit = timeoutCommit
+}
+
+// applyValidatorTimeout applies the start-only flag after config.toml is loaded.
+// Other commands also run the root PersistentPreRunE, but do not register this
+// flag and must continue without attempting to read it.
+func applyValidatorTimeout(cmd *cobra.Command) error {
+	if cmd.Flags().Lookup("consensus.timeout_commit") == nil {
+		return nil
+	}
+
+	timeoutCommit, err := cmd.Flags().GetDuration("consensus.timeout_commit")
+	if err != nil {
+		return err
+	}
+
+	setValidatorTimeout(server.GetServerContextFromCmd(cmd), timeoutCommit)
+	return nil
 }
 
 // initAppConfig helps to override default appConfig template and configs.

--- a/cmd/xiond/root_test.go
+++ b/cmd/xiond/root_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	tmcfg "github.com/cometbft/cometbft/config"
+
+	"github.com/cosmos/cosmos-sdk/server"
+)
+
+func TestSetValidatorTimeout(t *testing.T) {
+	serverCtx := server.NewDefaultContext()
+	serverCtx.Config = tmcfg.DefaultConfig()
+
+	setValidatorTimeout(serverCtx, 2500*time.Millisecond)
+
+	require.Equal(t, 2500*time.Millisecond, serverCtx.Config.Consensus.TimeoutCommit)
+}
+
+func TestValidatorTimeoutCommitFlag(t *testing.T) {
+	tests := map[string]struct {
+		args     []string
+		expected time.Duration
+	}{
+		"defaults to one second": {
+			expected: time.Second,
+		},
+		"accepts a CLI override": {
+			args:     []string{"--consensus.timeout_commit=2500ms"},
+			expected: 2500 * time.Millisecond,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			addModuleInitFlags(cmd)
+			require.NoError(t, cmd.Flags().Parse(tc.args))
+
+			timeoutCommit, err := cmd.Flags().GetDuration("consensus.timeout_commit")
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, timeoutCommit)
+		})
+	}
+}

--- a/cmd/xiond/root_test.go
+++ b/cmd/xiond/root_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -46,6 +47,7 @@ func TestApplyValidatorTimeout(t *testing.T) {
 			serverCtx := server.NewDefaultContext()
 			serverCtx.Config = tmcfg.DefaultConfig()
 			cmd := &cobra.Command{Use: "test"}
+			cmd.SetContext(context.Background())
 			require.NoError(t, server.SetCmdServerContext(cmd, serverCtx))
 			if tc.register {
 				addModuleInitFlags(cmd)

--- a/cmd/xiond/root_test.go
+++ b/cmd/xiond/root_test.go
@@ -21,15 +21,21 @@ func TestSetValidatorTimeout(t *testing.T) {
 	require.Equal(t, 2500*time.Millisecond, serverCtx.Config.Consensus.TimeoutCommit)
 }
 
-func TestValidatorTimeoutCommitFlag(t *testing.T) {
+func TestApplyValidatorTimeout(t *testing.T) {
 	tests := map[string]struct {
+		register bool
 		args     []string
 		expected time.Duration
 	}{
+		"ignores commands without the start flag": {
+			expected: tmcfg.DefaultConsensusConfig().TimeoutCommit,
+		},
 		"defaults to one second": {
+			register: true,
 			expected: time.Second,
 		},
 		"accepts a CLI override": {
+			register: true,
 			args:     []string{"--consensus.timeout_commit=2500ms"},
 			expected: 2500 * time.Millisecond,
 		},
@@ -37,13 +43,16 @@ func TestValidatorTimeoutCommitFlag(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := &cobra.Command{}
-			addModuleInitFlags(cmd)
+			serverCtx := server.NewDefaultContext()
+			serverCtx.Config = tmcfg.DefaultConfig()
+			cmd := &cobra.Command{Use: "test"}
+			require.NoError(t, server.SetCmdServerContext(cmd, serverCtx))
+			if tc.register {
+				addModuleInitFlags(cmd)
+			}
 			require.NoError(t, cmd.Flags().Parse(tc.args))
-
-			timeoutCommit, err := cmd.Flags().GetDuration("consensus.timeout_commit")
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, timeoutCommit)
+			require.NoError(t, applyValidatorTimeout(cmd))
+			require.Equal(t, tc.expected, serverCtx.Config.Consensus.TimeoutCommit)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/burnt-labs/abstract-account v0.1.5
 	github.com/burnt-labs/barretenberg-go v0.5.5
-	github.com/cometbft/cometbft v0.38.21
+	github.com/cometbft/cometbft v0.38.22
 	github.com/cosmos/cosmos-db v1.1.3
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.53.6
@@ -233,13 +233,13 @@ require (
 	github.com/lestrrat-go/httprc v1.0.6 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
-	github.com/lib/pq v1.10.9 // indirect
+	github.com/lib/pq v1.12.0 // indirect
 	github.com/linxGnu/grocksdb v1.10.3 // indirect
 	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mdp/qrterminal/v3 v3.2.1 // indirect
-	github.com/minio/highwayhash v1.0.3 // indirect
+	github.com/minio/highwayhash v1.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
@@ -261,7 +261,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/zerolog v1.34.0
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/sasha-s/go-deadlock v0.3.6 // indirect
+	github.com/sasha-s/go-deadlock v0.3.9 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shamaton/msgpack/v2 v2.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb/go.mod h1:
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/mesh-sdk-go/types v1.0.0 h1:CQjX3SnIZvRClvSgjgNDLq342Wn9WNnGnpSfkmMu8nE=
 github.com/coinbase/mesh-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.38.21 h1:qcIJSH9LiwU5s6ZgKR5eRbsLNucbubfraDs5bzgjtOI=
-github.com/cometbft/cometbft v0.38.21/go.mod h1:UCu8dlHqvkAsmAFmWDRWNZJPlu6ya2fTWZlDrWsivwo=
+github.com/cometbft/cometbft v0.38.22 h1:T9BLO8f4DOhvQ5ic9ULq+4WjOlgxeKtFt2lR0IL5Qos=
+github.com/cometbft/cometbft v0.38.22/go.mod h1:jtH//cs5e2U5dNiaYIPMBwWXZsedXJfIie77gVhuRaA=
 github.com/cometbft/cometbft-db v1.0.4 h1:cezb8yx/ZWcF124wqUtAFjAuDksS1y1yXedvtprUFxs=
 github.com/cometbft/cometbft-db v1.0.4/go.mod h1:M+BtHAGU2XLrpUxo3Nn1nOCcnVCiLM9yx5OuT0u5SCA=
 github.com/consensys/gnark v0.14.0 h1:RG+8WxRanFSFBSlmCDRJnYMYYKpH3Ncs5SMzg24B5HQ=
@@ -728,8 +728,8 @@ github.com/lestrrat-go/jwx/v2 v2.1.6 h1:hxM1gfDILk/l5ylers6BX/Eq1m/pnxe9NBwW6lVf
 github.com/lestrrat-go/jwx/v2 v2.1.6/go.mod h1:Y722kU5r/8mV7fYDifjug0r8FK8mZdw0K0GpJw/l8pU=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.12.0 h1:mC1zeiNamwKBecjHarAr26c/+d8V5w/u4J0I/yASbJo=
+github.com/lib/pq v1.12.0/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linxGnu/grocksdb v1.10.3 h1:0laII9AQ6kFxo5SjhdTfSh9EgF20piD6TMHK6YuDm+4=
@@ -764,8 +764,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
 github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
-github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
+github.com/minio/highwayhash v1.0.4 h1:asJizugGgchQod2ja9NJlGOWq4s7KsAWr5XUc9Clgl4=
+github.com/minio/highwayhash v1.0.4/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -951,8 +951,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/sasha-s/go-deadlock v0.3.6 h1:TR7sfOnZ7x00tWPfD397Peodt57KzMDo+9Ae9rMiUmw=
-github.com/sasha-s/go-deadlock v0.3.6/go.mod h1:CUqNyyvMxTyjFqDT7MRg9mb4Dv/btmGTqSR+rky/UXo=
+github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
+github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=


### PR DESCRIPTION
## Summary
- upgrade CometBFT from v0.38.21 to v0.38.22 so peers advertise the correct CometBFT version
- make `--consensus.timeout_commit` a duration flag with a 1-second default
- apply the flag after `config.toml` is loaded, but only for commands that register the start-only flag
- add regression coverage for the default, an explicit CLI override, and non-start commands
- retain the indirect `lib/pq`, `minio/highwayhash`, and `go-deadlock` updates produced by the CometBFT module refresh

## Validation
- `go mod verify`
- `go test ./... -count=1`
- repository pre-commit formatting and lint hooks
- repository coverage gate: 86.1% overall, no functions below 50%
- focused local re-run reached the linker but is blocked on this machine by the existing invalid `barretenberg-go` darwin archive